### PR TITLE
feat: 1518 refactor create note of interest

### DIFF
--- a/src/processes/parkingspaces/internal/create-note-of-interest.ts
+++ b/src/processes/parkingspaces/internal/create-note-of-interest.ts
@@ -1,9 +1,10 @@
-import { HttpStatusCode } from 'axios'
+import { AxiosResponse, HttpStatusCode } from 'axios'
 import {
   parkingSpaceApplicationCategoryTranslation,
   ParkingSpaceApplicationCategory,
   Applicant,
   ApplicantStatus,
+  Contact,
 } from 'onecore-types'
 import {
   getContact,
@@ -121,62 +122,30 @@ export const createNoteOfInterestForInternalParkingSpace = async (
       applicantContact.nationalRegistrationNumber
     )
 
-    let shouldAddApplicantToWaitingList = false
-    let isInWaitingListForInternalParking = false
-    let isInWaitingListForExternalParking = false
-    if (waitingList.length > 0) {
-      isInWaitingListForInternalParking = waitingList.some(
-        (o) => o.waitingListTypeCaption === 'Bilplats (intern)'
-      )
-      isInWaitingListForExternalParking = waitingList.some(
-        (o) => o.waitingListTypeCaption === 'Bilplats (extern)'
-      )
-      if (
-        !isInWaitingListForInternalParking ||
-        !isInWaitingListForExternalParking
-      ) {
-        shouldAddApplicantToWaitingList = true
-      }
-    } else {
-      shouldAddApplicantToWaitingList = true
-    }
+    const waitingListStatus = evaluateWaitingListStatus(waitingList)
+    const shouldAddApplicantToWaitingList =
+      waitingListStatus.shouldAddApplicantToWaitingList
+    const isInWaitingListForInternalParking =
+      waitingListStatus.isInWaitingListForInternalParking
+    const isInWaitingListForExternalParking =
+      waitingListStatus.isInWaitingListForExternalParking
+
     //xpand handles internal and external waiting list synonymously
     //a user should therefore always be placed in both waiting list
     if (shouldAddApplicantToWaitingList) {
-      if (!isInWaitingListForInternalParking) {
-        log.push(`Sökande saknas i kö för intern parkeringsplats.`)
-        const result = await addApplicantToWaitingList(
-          applicantContact.nationalRegistrationNumber,
-          applicantContact.contactCode,
-          'Bilplats (intern)'
-        )
-        if (result.status == HttpStatusCode.Created) {
-          log.push(`Sökande placerad i kö för intern parkeringsplats`)
-        } else {
-          logger.error(
-            result,
-            'Could not add applicant to internal waiting list'
-          )
-          throw Error(result.statusText)
-        }
-      }
-      if (!isInWaitingListForExternalParking) {
-        log.push(`Sökande saknas i kö för extern parkeringsplats.`)
-        const result = await addApplicantToWaitingList(
-          applicantContact.nationalRegistrationNumber,
-          applicantContact.contactCode,
-          'Bilplats (extern)'
-        )
-        if (result.status == HttpStatusCode.Created) {
-          log.push(`Sökande placerad i kö för extern parkeringsplats`)
-        } else {
-          logger.error(
-            result,
-            'Could not add applicant to external waiting list'
-          )
-          throw Error(result.statusText)
-        }
-      }
+      await handleWaitingList(
+        isInWaitingListForInternalParking,
+        'intern',
+        applicantContact,
+        log
+      )
+
+      await handleWaitingList(
+        isInWaitingListForExternalParking,
+        'extern',
+        applicantContact,
+        log
+      )
     }
 
     log.push(
@@ -210,19 +179,12 @@ export const createNoteOfInterestForInternalParkingSpace = async (
       )
 
       //create new applicant if applicant does not exist
-      //todo: use request type
       if (applicantResponse.status == HttpStatusCode.NotFound) {
-        const applicantRequestBody: Applicant = {
-          id: 0, //should not be passed
-          name: applicantContact.fullName,
-          nationalRegistrationNumber:
-            applicantContact.nationalRegistrationNumber,
-          contactCode: applicantContact.contactCode,
-          applicationDate: new Date(),
-          applicationType: applicationType,
-          status: ApplicantStatus.Active,
-          listingId: listing.data?.id, //null should not be allowed
-        }
+        const applicantRequestBody = createApplicantRequestBody(
+          applicantContact,
+          applicationType,
+          listing
+        )
 
         const applyForListingResult =
           await applyForListing(applicantRequestBody)
@@ -301,5 +263,76 @@ export const createNoteOfInterestForInternalParkingSpace = async (
     return makeProcessError('internal-error', 500, {
       message: error.message,
     })
+  }
+}
+
+const createApplicantRequestBody = (
+  applicantContact: Contact,
+  applicationType: string,
+  listing: AxiosResponse<any>
+) => {
+  const applicantRequestBody: Applicant = {
+    id: 0, //should not be passed
+    name: applicantContact.fullName,
+    nationalRegistrationNumber: applicantContact.nationalRegistrationNumber,
+    contactCode: applicantContact.contactCode,
+    applicationDate: new Date(),
+    applicationType: applicationType,
+    status: ApplicantStatus.Active,
+    listingId: listing.data?.id, //null should not be allowed
+  }
+  return applicantRequestBody
+}
+
+const evaluateWaitingListStatus = (waitingList: any) => {
+  let shouldAddApplicantToWaitingList = false
+  let isInWaitingListForInternalParking = false
+  let isInWaitingListForExternalParking = false
+
+  if (waitingList.length > 0) {
+    isInWaitingListForInternalParking = waitingList.some(
+      (o: any) => o.waitingListTypeCaption === 'Bilplats (intern)'
+    )
+    isInWaitingListForExternalParking = waitingList.some(
+      (o: any) => o.waitingListTypeCaption === 'Bilplats (extern)'
+    )
+    if (
+      !isInWaitingListForInternalParking ||
+      !isInWaitingListForExternalParking
+    ) {
+      shouldAddApplicantToWaitingList = true
+    }
+  } else {
+    shouldAddApplicantToWaitingList = true
+  }
+
+  return {
+    shouldAddApplicantToWaitingList,
+    isInWaitingListForInternalParking,
+    isInWaitingListForExternalParking,
+  }
+}
+const handleWaitingList = async (
+  isInWaitingList: boolean,
+  parkingType: string,
+  applicantContact: Contact,
+  log: any[]
+) => {
+  if (!isInWaitingList) {
+    log.push(`Sökande saknas i kö för ${parkingType} parkeringsplats.`)
+    const result = await addApplicantToWaitingList(
+      applicantContact.nationalRegistrationNumber,
+      applicantContact.contactCode,
+      `Bilplats (${parkingType})`
+    )
+    if (result.status == HttpStatusCode.Created) {
+      log.push(`Sökande placerad i kö för ${parkingType} parkeringsplats`)
+    } else {
+      logger.error(
+        result,
+        `Could not add applicant to ${parkingType} waiting list`
+      )
+      throw Error(result.statusText)
+    }
   }
 }

--- a/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
+++ b/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
@@ -32,7 +32,8 @@ import {
   mockedListing,
   mockedListingWithDetailedApplicants,
 } from '../../../../adapters/tests/leasing-adapter.mocks'
-import { ApplicantStatus } from 'onecore-types'
+import { ApplicantStatus, ListingStatus } from 'onecore-types'
+import * as factory from '../../../../../test/factories'
 
 const createAxiosResponse = (status: number, data: any): AxiosResponse => {
   return {
@@ -418,21 +419,27 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       )
 
     expect(response.processStatus).toBe(ProcessStatus.successful)
+    expect(response.response.message).toBe(
+      'Applicant bar successfully applied to parking space foo'
+    )
     expect(response.httpStatus).toBe(200)
   })
 
-  it('returns ProcessStatus.inProgress if applicant has an application to this listing already', async () => {
+  it('returns ProcessStatus.Success if applicant has an application to this listing already', async () => {
     getContactSpy.mockResolvedValue(mockedApplicant)
     getParkingSpaceSpy.mockResolvedValue(mockedParkingSpace)
     getLeasesForPnrSpy.mockResolvedValue(mockedLeases)
     getInternalCreditInformationSpy.mockResolvedValue(true)
     getWaitingListSpy.mockResolvedValue(mockedWaitingList)
+    createNewListingSpy.mockResolvedValue(
+      createAxiosResponse(HttpStatusCode.Created, mockedListing)
+    )
     applyForListingSpy.mockResolvedValue({
       status: HttpStatusCode.Conflict,
     } as any)
     getListingByRentalObjectCodeSpy.mockResolvedValue({
       status: HttpStatusCode.NotFound,
-      data: {},
+      data: factory.listing.build({ status: ListingStatus.Active }),
       statusText: '',
       headers: {},
       config: {} as InternalAxiosRequestConfig,
@@ -447,8 +454,10 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
         'bar',
         'baz'
       )
-
     expect(response.processStatus).toBe(ProcessStatus.successful)
+    expect(response.response.message).toBe(
+      'Applicant bar already has application for foo'
+    )
   })
 
   it('returns ProcessStatus.Success if the user applies a second time after the user has withdrawn the application', async () => {
@@ -482,5 +491,44 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       )
 
     expect(response.processStatus).toBe(ProcessStatus.successful)
+    expect(response.response.message).toBe(
+      'Applicant bar successfully applied to parking space foo'
+    )
+  })
+
+  it('returns ProcessStatus.Success if the user already have active application', async () => {
+    getContactSpy.mockResolvedValue(mockedApplicant)
+    getParkingSpaceSpy.mockResolvedValue(mockedParkingSpace)
+    getLeasesForPnrSpy.mockResolvedValue(mockedLeases)
+    getInternalCreditInformationSpy.mockResolvedValue(true)
+    getWaitingListSpy.mockResolvedValue(mockedWaitingList)
+    applyForListingSpy.mockResolvedValue({
+      status: HttpStatusCode.Ok,
+    } as any)
+    getListingByRentalObjectCodeSpy.mockResolvedValue({
+      status: HttpStatusCode.Ok,
+      data: {},
+      statusText: '',
+      headers: {},
+      config: {} as InternalAxiosRequestConfig,
+    })
+    getApplicantByContactCodeAndListingIdSpy.mockResolvedValue({
+      status: HttpStatusCode.Ok,
+      data: {
+        status: ApplicantStatus.Active,
+      },
+    })
+
+    const response =
+      await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
+        'foo',
+        'bar',
+        'baz'
+      )
+
+    expect(response.processStatus).toBe(ProcessStatus.successful)
+    expect(response.response.message).toBe(
+      'Applicant bar already has application for foo'
+    )
   })
 })

--- a/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
+++ b/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
@@ -32,6 +32,7 @@ import {
   mockedListing,
   mockedListingWithDetailedApplicants,
 } from '../../../../adapters/tests/leasing-adapter.mocks'
+import { ApplicantStatus } from 'onecore-types'
 
 const createAxiosResponse = (status: number, data: any): AxiosResponse => {
   return {
@@ -86,6 +87,10 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
   jest
     .spyOn(leasingAdapter, 'createNewListing')
     .mockResolvedValue(createAxiosResponse(HttpStatusCode.Created, null))
+
+  jest
+    .spyOn(leasingAdapter, 'setApplicantStatusActive')
+    .mockResolvedValue(createAxiosResponse(HttpStatusCode.Ok, null))
 
   it('gets the parking space', async () => {
     getParkingSpaceSpy.mockResolvedValue(mockedParkingSpace)
@@ -447,6 +452,35 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
   })
 
   it('returns ProcessStatus.Success if the user applies a second time after the user has withdrawn the application', async () => {
-    console.log('implement')
+    getContactSpy.mockResolvedValue(mockedApplicant)
+    getParkingSpaceSpy.mockResolvedValue(mockedParkingSpace)
+    getLeasesForPnrSpy.mockResolvedValue(mockedLeases)
+    getInternalCreditInformationSpy.mockResolvedValue(true)
+    getWaitingListSpy.mockResolvedValue(mockedWaitingList)
+    applyForListingSpy.mockResolvedValue({
+      status: HttpStatusCode.Ok,
+    } as any)
+    getListingByRentalObjectCodeSpy.mockResolvedValue({
+      status: HttpStatusCode.Ok,
+      data: {},
+      statusText: '',
+      headers: {},
+      config: {} as InternalAxiosRequestConfig,
+    })
+    getApplicantByContactCodeAndListingIdSpy.mockResolvedValue({
+      status: HttpStatusCode.Ok,
+      data: {
+        status: ApplicantStatus.WithdrawnByUser,
+      },
+    })
+
+    const response =
+      await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
+        'foo',
+        'bar',
+        'baz'
+      )
+
+    expect(response.processStatus).toBe(ProcessStatus.successful)
   })
 })


### PR DESCRIPTION
https://dev.azure.com/mimeronline/ONECore/_boards/board/t/Dev/Issues/?workitem=1518

* Adds missing test for case when applicant re-applies to listing with applicant status "withdrawn"
* refactors some of the process logic into functions

### Bugfix 🐛 

The process previously returned the error `Create not of interest for internal parking space failed due to unknown error` when applicant already existed and had status "active". This PR resolves this by a return of statuscode 200 and message `Applicant ${contactCode} already has application for ${parkingSpaceId}`,  