### PR TITLE
1560 - Apply area and address specific rental property rules when creating applicant in internal portal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "koa-pino-logger": "^4.0.0",
         "koa2-swagger-ui": "^5.10.0",
         "odoo-await": "^3.4.1",
-        "onecore-types": "^1.25.0",
+        "onecore-types": "^1.26.0",
         "onecore-utilities": "^1.1.0",
         "pino": "^9.1.0",
         "pino-elasticsearch": "^8.0.0",
@@ -7529,9 +7529,9 @@
       }
     },
     "node_modules/onecore-types": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.25.0.tgz",
-      "integrity": "sha512-IonqJIW7jbfpAMliNhVrQgdEcDBqZMUnI3BROAhkS9wbYOO+JV1mirgzHerxnkho70SrTUgSnkq+6QK4L3+cQw==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.26.0.tgz",
+      "integrity": "sha512-AMkyk253xMEKG04UbNnRv5WzIG1DD/izn2ObjL7a9VrDipX0JduDblfyOt/HMmlSuiosRXr4aQPaL4MSpMglUg==",
       "dependencies": {
         "release-please": "^16.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "koa-pino-logger": "^4.0.0",
     "koa2-swagger-ui": "^5.10.0",
     "odoo-await": "^3.4.1",
-    "onecore-types": "^1.25.0",
+    "onecore-types": "^1.26.0",
     "onecore-utilities": "^1.1.0",
     "pino": "^9.1.0",
     "pino-elasticsearch": "^8.0.0",

--- a/src/adapters/leasing-adapter.ts
+++ b/src/adapters/leasing-adapter.ts
@@ -501,6 +501,17 @@ const getOfferByContactCodeAndOfferId = async (
   }
 }
 
+type ValidateRentalRulesResult = AdapterResult<
+  { reason: string },
+  | 'not-found'
+  | 'unknown'
+  | 'contact-not-found'
+  | 'not-a-parking-space'
+  | 'no-contract-in-the-area'
+  | 'not-allowed-to-rent-additional'
+  | 'unexpected-error'
+>
+
 const validateRentalRules = (
   validationResult: AxiosResponse,
   applicationType: string
@@ -557,18 +568,7 @@ const validateResidentialAreaRentalRules = async (
   contactCode: string,
   districtCode: string,
   applicationType: string
-): Promise<
-  AdapterResult<
-    { reason: string },
-    | 'not-found'
-    | 'unknown'
-    | 'contact-not-found'
-    | 'not-a-parking-space'
-    | 'no-contract-in-the-area'
-    | 'not-allowed-to-rent-additional'
-    | 'unexpected-error'
-  >
-> => {
+): Promise<ValidateRentalRulesResult> => {
   try {
     const res = await axios(
       `${tenantsLeasesServiceUrl}/applicants/validateResidentialAreaRentalRules/${contactCode}/${districtCode}`

--- a/src/adapters/leasing-adapter.ts
+++ b/src/adapters/leasing-adapter.ts
@@ -131,6 +131,23 @@ const getContactByContactCode = async (
   }
 }
 
+const getTenantByContactCode = async (
+  contactCode: string
+): Promise<AdapterResult<any, unknown>> => {
+  try {
+    const res = await axios.get(
+      `${tenantsLeasesServiceUrl}/tenant/contactCode/${contactCode}`
+    )
+
+    if (!res.data.data) return { ok: false, err: 'not-found' }
+
+    return { ok: true, data: res.data.data }
+  } catch (err) {
+    logger.error({ err }, 'leasing-adapter.getTenantByContactCode')
+    return { ok: false, err: 'unknown' }
+  }
+}
+
 const getContactForPhoneNumber = async (
   phoneNumber: string
 ): Promise<Contact | undefined> => {
@@ -585,4 +602,5 @@ export {
   getOfferByContactCodeAndOfferId,
   validateResidentialAreaRentalRules,
   validatePropertyRentalRules,
+  getTenantByContactCode,
 }

--- a/src/adapters/leasing-adapter.ts
+++ b/src/adapters/leasing-adapter.ts
@@ -15,6 +15,7 @@ import {
   DetailedApplicant,
   OfferWithRentalObjectCode,
   DetailedOffer,
+  Tenant,
 } from 'onecore-types'
 import config from '../common/config'
 import dayjs from 'dayjs'
@@ -131,10 +132,9 @@ const getContactByContactCode = async (
   }
 }
 
-// TODO: Use Tenant type for return
 const getTenantByContactCode = async (
   contactCode: string
-): Promise<AdapterResult<any, 'unknown'>> => {
+): Promise<AdapterResult<Tenant, 'unknown'>> => {
   try {
     const res = await axios.get(
       `${tenantsLeasesServiceUrl}/tenants/contactCode/${contactCode}`

--- a/src/adapters/leasing-adapter.ts
+++ b/src/adapters/leasing-adapter.ts
@@ -131,17 +131,18 @@ const getContactByContactCode = async (
   }
 }
 
+// TODO: Use Tenant type for return
 const getTenantByContactCode = async (
   contactCode: string
-): Promise<AdapterResult<any, unknown>> => {
+): Promise<AdapterResult<any, 'unknown'>> => {
   try {
     const res = await axios.get(
-      `${tenantsLeasesServiceUrl}/tenant/contactCode/${contactCode}`
+      `${tenantsLeasesServiceUrl}/tenants/contactCode/${contactCode}`
     )
 
-    if (!res.data.data) return { ok: false, err: 'not-found' }
+    if (!res.data.content) return { ok: false, err: 'unknown' }
 
-    return { ok: true, data: res.data.data }
+    return { ok: true, data: res.data.content }
   } catch (err) {
     logger.error({ err }, 'leasing-adapter.getTenantByContactCode')
     return { ok: false, err: 'unknown' }

--- a/src/adapters/leasing-adapter.ts
+++ b/src/adapters/leasing-adapter.ts
@@ -304,15 +304,17 @@ const getListingByRentalObjectCode = async (rentalObjectCode: string) => {
   }
 }
 
-const getListingsWithApplicants = async (): Promise<any[] | undefined> => {
+const getListingsWithApplicants = async (): Promise<
+  AdapterResult<any[] | undefined, 'unknown'>
+> => {
   try {
     const response = await axios.get(
       `${tenantsLeasesServiceUrl}/listings-with-applicants`
     )
-    return response.data.content
+    return { ok: true, data: response.data.content }
   } catch (error) {
     logger.error(error, 'Error fetching listings with applicants:')
-    return undefined
+    return { ok: false, err: 'unknown' }
   }
 }
 

--- a/src/adapters/tests/leasing-adapter.test.ts
+++ b/src/adapters/tests/leasing-adapter.test.ts
@@ -580,81 +580,54 @@ describe('leasing-adapter', () => {
       nock(config.tenantsLeasesService.url)
         .get(/applicants\/validateResidentialAreaRentalRules/)
         .reply(200, { applicationType: 'Replace' })
+
       const result = await leasingAdapter.validateResidentialAreaRentalRules(
         '123',
-        'ABC',
-        'Replace'
+        'ABC'
       )
 
       expect(result.ok).toBe(true)
     })
-    it('calls leasing and parses a failing validation result', async () => {
-      nock(config.tenantsLeasesService.url)
-        .get(/applicants\/validateResidentialAreaRentalRules/)
-        .reply(200, { applicationType: 'Replace' })
-      const result = await leasingAdapter.validateResidentialAreaRentalRules(
-        '123',
-        'ABC',
-        'Additional'
-      )
 
-      expect(result.ok).toBe(false)
-      if (!result.ok) expect(result.err).toBe('not-allowed-to-rent-additional')
-    })
     it('calls leasing and returns an error', async () => {
       nock(config.tenantsLeasesService.url)
         .get(/applicants\/validateResidentialAreaRentalRules/)
         .reply(400, { reason: 'some-reason' })
+
       const result = await leasingAdapter.validateResidentialAreaRentalRules(
         '123',
-        'ABC',
-        'Additional'
+        'ABC'
       )
 
-      expect(result.ok).toBe(false)
-      if (!result.ok) {
-        expect(result.err).toBe('not-a-parking-space')
-      }
+      expect(result).toEqual({ ok: false, err: 'unknown' })
     })
   })
+
   describe(leasingAdapter.validatePropertyRentalRules, () => {
     it('calls leasing and parses a passing validation result', async () => {
       nock(config.tenantsLeasesService.url)
         .get(/applicants\/validatePropertyRentalRules/)
         .reply(200, { applicationType: 'Replace' })
+
       const result = await leasingAdapter.validatePropertyRentalRules(
         '123',
-        'ABC',
-        'Replace'
+        'ABC'
       )
 
       expect(result.ok).toBe(true)
     })
-    it('calls leasing and parses a failing validation result', async () => {
-      nock(config.tenantsLeasesService.url)
-        .get(/applicants\/validatePropertyRentalRules/)
-        .reply(200, { applicationType: 'Replace' })
-      const result = await leasingAdapter.validatePropertyRentalRules(
-        '123',
-        'ABC',
-        'Additional'
-      )
 
-      expect(result.ok).toBe(false)
-      if (!result.ok) expect(result.err).toBe('not-allowed-to-rent-additional')
-    })
     it('calls leasing and returns an error', async () => {
       nock(config.tenantsLeasesService.url)
         .get(/applicants\/validatePropertyRentalRules/)
         .reply(403, { reason: 'some-other-reason' })
+
       const result = await leasingAdapter.validatePropertyRentalRules(
         '123',
-        'ABC',
-        'Additional'
+        'ABC'
       )
 
-      expect(result.ok).toBe(false)
-      if (!result.ok) expect(result.err).toBe('no-contract-in-the-area')
+      expect(result).toEqual({ ok: false, err: 'not-tenant-in-the-property' })
     })
   })
 })

--- a/src/adapters/tests/leasing-adapter.test.ts
+++ b/src/adapters/tests/leasing-adapter.test.ts
@@ -599,7 +599,7 @@ describe('leasing-adapter', () => {
         'ABC'
       )
 
-      expect(result).toEqual({ ok: false, err: 'unknown' })
+      expect(result).toMatchObject({ ok: false, err: { tag: 'unknown' } })
     })
   })
 
@@ -627,7 +627,10 @@ describe('leasing-adapter', () => {
         'ABC'
       )
 
-      expect(result).toEqual({ ok: false, err: 'not-tenant-in-the-property' })
+      expect(result).toMatchObject({
+        ok: false,
+        err: { tag: 'not-tenant-in-the-property' },
+      })
     })
   })
 })

--- a/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
+++ b/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
@@ -31,6 +31,7 @@ import { HttpStatusCode, InternalAxiosRequestConfig } from 'axios'
 import { mockedDetailedApplicants } from '../../../../adapters/tests/leasing-adapter.mocks'
 import { ApplicantStatus, ListingStatus } from 'onecore-types'
 import * as factory from '../../../../../test/factories'
+import * as processUtils from '../../utils'
 
 const createAxiosResponse = (status: number, data: any): AxiosResponse => {
   return {
@@ -81,11 +82,19 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
 
   const validatePropertyRentalRules = jest
     .spyOn(leasingAdapter, 'validatePropertyRentalRules')
-    .mockResolvedValue({ ok: true, data: { reason: '' } })
+    .mockResolvedValue({
+      ok: true,
+      data: { reason: '', applicationType: 'Additional' },
+    })
 
   const validateResidentialAreaRentalRules = jest
     .spyOn(leasingAdapter, 'validateResidentialAreaRentalRules')
-    .mockResolvedValue({ ok: true, data: { reason: '' } })
+    .mockResolvedValue({
+      ok: true,
+      data: { reason: '', applicationType: 'Additional' },
+    })
+
+  const validateRentalRules = jest.spyOn(processUtils, 'validateRentalRules')
 
   jest
     .spyOn(leasingAdapter, 'getListingByRentalObjectCode')
@@ -103,7 +112,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
       'foo',
       'bar',
-      'baz'
+      'Additional'
     )
 
     expect(getParkingSpaceSpy).toHaveBeenCalledWith('foo')
@@ -116,7 +125,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
 
     expect(result.processStatus).toBe(ProcessStatus.failed)
@@ -132,7 +141,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
 
     expect(result.processStatus).toBe(ProcessStatus.failed)
@@ -149,7 +158,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
 
     expect(result.processStatus).toBe(ProcessStatus.failed)
@@ -162,7 +171,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
       'foo',
       'bar',
-      'baz'
+      'Additional'
     )
 
     expect(getContactSpy).toHaveBeenCalledWith('bar')
@@ -176,7 +185,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
 
     expect(result.processStatus).toBe(ProcessStatus.failed)
@@ -189,9 +198,13 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     getLeasesForPnrSpy.mockResolvedValue(mockedLeases)
     validatePropertyRentalRules.mockResolvedValueOnce({
       ok: false,
-      err: 'not-found',
+      err: 'property-info-not-found',
     })
     validateResidentialAreaRentalRules.mockResolvedValueOnce({
+      ok: false,
+      err: 'no-housing-contract-in-the-area',
+    })
+    validateRentalRules.mockReturnValueOnce({
       ok: false,
       err: 'not-allowed-to-rent-additional',
     })
@@ -200,14 +213,15 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
 
-    expect(result.processStatus).toBe(ProcessStatus.failed)
-    if (result.processStatus == ProcessStatus.failed) {
-      expect(result.httpStatus).toBe(400)
-      expect(result.error).toBe('not-allowed-to-rent-additional')
-    }
+    expect(result).toEqual({
+      processStatus: ProcessStatus.failed,
+      httpStatus: 400,
+      error: 'not-allowed-to-rent-additional',
+      response: undefined,
+    })
   })
 
   it('performs internal credit check', async () => {
@@ -219,7 +233,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
       'foo',
       'bar',
-      'baz'
+      'Additional'
     )
 
     expect(getInternalCreditInformationSpy).toHaveBeenCalledWith('P12345')
@@ -235,7 +249,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
 
     expect(result.processStatus).toBe(ProcessStatus.failed)
@@ -264,7 +278,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
       'foo',
       'bar',
-      'baz'
+      'Additional'
     )
 
     expect(addApplicantToWaitingListSpy).toHaveBeenCalledWith(
@@ -305,7 +319,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
       'foo',
       'bar',
-      'baz'
+      'Additional'
     )
 
     expect(addApplicantToWaitingListSpy).toHaveBeenCalledWith(
@@ -326,7 +340,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
       'foo',
       'bar',
-      'baz'
+      'Additional'
     )
 
     expect(getListingByRentalObjectCodeSpy).toHaveBeenCalledWith('foo')
@@ -350,7 +364,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
       'foo',
       'bar',
-      'baz'
+      'Additional'
     )
 
     expect(createNewListingSpy).toHaveBeenCalledWith({
@@ -398,12 +412,12 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
       'foo',
       'bar',
-      'baz'
+      'Additional'
     )
 
     expect(applyForListingSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        applicationType: 'baz',
+        applicationType: 'Additional',
         contactCode: 'P12345',
         id: 0,
         listingId: undefined,
@@ -447,7 +461,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
 
     expect(response.processStatus).toBe(ProcessStatus.successful)
@@ -487,7 +501,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
     expect(response.processStatus).toBe(ProcessStatus.successful)
     expect(response.response.message).toBe(
@@ -522,7 +536,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
 
     expect(response.processStatus).toBe(ProcessStatus.successful)
@@ -558,7 +572,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
       await parkingProcesses.createNoteOfInterestForInternalParkingSpace(
         'foo',
         'bar',
-        'baz'
+        'Additional'
       )
 
     expect(response.processStatus).toBe(ProcessStatus.successful)

--- a/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
+++ b/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
@@ -198,11 +198,11 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
     getLeasesForPnrSpy.mockResolvedValue(mockedLeases)
     validatePropertyRentalRules.mockResolvedValueOnce({
       ok: false,
-      err: 'property-info-not-found',
+      err: { tag: 'not-found', data: null },
     })
     validateResidentialAreaRentalRules.mockResolvedValueOnce({
       ok: false,
-      err: 'no-housing-contract-in-the-area',
+      err: { tag: 'no-housing-contract-in-the-area', data: null },
     })
     validateRentalRules.mockReturnValueOnce({
       ok: false,

--- a/src/processes/parkingspaces/utils.ts
+++ b/src/processes/parkingspaces/utils.ts
@@ -23,17 +23,17 @@ export const validateRentalRules = (
   applicationType: 'Replace' | 'Additional'
 ) => {
   if (!validationResult.ok) {
-    if (validationResult.err === 'property-info-not-found') {
+    if (validationResult.err.tag === 'not-found') {
       return { ok: false, err: 'not-found' }
     }
 
-    if (validationResult.err === 'not-a-parking-space') {
+    if (validationResult.err.tag === 'not-a-parking-space') {
       return { ok: false, err: 'not-a-parking-space' }
     }
 
     if (
-      validationResult.err === 'not-tenant-in-the-property' ||
-      validationResult.err === 'no-housing-contract-in-the-area'
+      validationResult.err.tag === 'not-tenant-in-the-property' ||
+      validationResult.err.tag === 'no-housing-contract-in-the-area'
     ) {
       return { ok: false, err: 'no-contract-in-the-area' }
     }

--- a/src/processes/parkingspaces/utils.ts
+++ b/src/processes/parkingspaces/utils.ts
@@ -1,4 +1,5 @@
 import { ProcessError, ProcessStatus } from '../../common/types'
+import * as leasingAdapter from '../../adapters/leasing-adapter'
 
 export const makeProcessError = <E = any>(
   error: E,
@@ -10,3 +11,49 @@ export const makeProcessError = <E = any>(
   httpStatus,
   response,
 })
+
+type ValidationResult =
+  | Awaited<ReturnType<typeof leasingAdapter.validatePropertyRentalRules>>
+  | Awaited<
+      ReturnType<typeof leasingAdapter.validateResidentialAreaRentalRules>
+    >
+
+export const validateRentalRules = (
+  validationResult: ValidationResult,
+  applicationType: 'Replace' | 'Additional'
+) => {
+  if (!validationResult.ok) {
+    if (validationResult.err === 'property-info-not-found') {
+      return { ok: false, err: 'not-found' }
+    }
+
+    if (validationResult.err === 'not-a-parking-space') {
+      return { ok: false, err: 'not-a-parking-space' }
+    }
+
+    if (
+      validationResult.err === 'not-tenant-in-the-property' ||
+      validationResult.err === 'no-housing-contract-in-the-area'
+    ) {
+      return { ok: false, err: 'no-contract-in-the-area' }
+    }
+    return { ok: false, err: 'unknown' }
+  }
+
+  if (validationResult.data.applicationType == 'Additional') {
+    //Applicant is allowed to rent an additional parking space in this area
+    return { ok: true, data: { reason: validationResult.data.reason } }
+  } else if (
+    validationResult.data.applicationType == 'Replace' &&
+    applicationType == 'Replace'
+  ) {
+    //Applicant is allowed to replace their current parking space for a new one in this area
+    return { ok: true, data: { reason: validationResult.data.reason } }
+  } else {
+    //Applicant is not allowed to rent an additional parking space in this area
+    return {
+      ok: false,
+      err: 'not-allowed-to-rent-additional',
+    }
+  }
+}

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -513,9 +513,16 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('/listings-with-applicants', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await leasingAdapter.getListingsWithApplicants()
+    const result = await leasingAdapter.getListingsWithApplicants()
 
-    ctx.body = { content: responseData, ...metadata }
+    if (!result.ok) {
+      ctx.status = 500
+      ctx.body = { error: 'Unknown error', ...metadata }
+      return
+    }
+
+    ctx.status = 200
+    ctx.body = { content: result.data, ...metadata }
   })
 
   /**

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -575,6 +575,46 @@ export const routes = (router: KoaRouter) => {
     ctx.body = { content: responseData, ...metadata }
   })
 
+  // router.get(
+  // '(.*)/applicants/validate-rental-rules/property/:contactCode/:rentalObjectCode',
+  // async (ctx) => {
+  // const res = await leasingAdapter.validatePropertyRentalRules(
+  // ctx.params.contactCode,
+  // ctx.params.rentalObjectCode
+  // )
+
+  // if (!res.ok) {
+  // ctx.status = 500
+  // return
+  // }
+
+  // ctx.status = 200
+  // ctx.body = {
+  // data: res.data,
+  // }
+  // }
+  // )
+
+  // router.get(
+  // '(.*)/applicants/validate-rental-rules/residential-area/:contactCode/:districtCode',
+  // async (ctx) => {
+  // const res = await leasingAdapter.validateResidentialAreaRentalRules(
+  // ctx.params.contactCode,
+  // ctx.params.districtCode
+  // )
+
+  // if (!res.ok) {
+  // ctx.status = 500
+  // return
+  // }
+
+  // ctx.status = 200
+  // ctx.body = {
+  // data: res.data,
+  // }
+  // }
+  // )
+
   /**
    * @swagger
    * /applicants-with-listings/{contactCode}:

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -361,6 +361,22 @@ export const routes = (router: KoaRouter) => {
     }
   })
 
+  router.get('(.*)/tenant/contactCode/:contactCode', async (ctx) => {
+    const res = await leasingAdapter.getTenantByContactCode(
+      ctx.params.contactCode
+    )
+
+    if (!res.ok) {
+      ctx.status = res.err === 'not-found' ? 404 : 500
+      return
+    }
+
+    ctx.status = 200
+    ctx.body = {
+      data: res.data,
+    }
+  })
+
   /**
    * @swagger
    * /contact/phoneNumber/{pnr}:
@@ -575,45 +591,55 @@ export const routes = (router: KoaRouter) => {
     ctx.body = { content: responseData, ...metadata }
   })
 
-  // router.get(
-  // '(.*)/applicants/validate-rental-rules/property/:contactCode/:rentalObjectCode',
-  // async (ctx) => {
-  // const res = await leasingAdapter.validatePropertyRentalRules(
-  // ctx.params.contactCode,
-  // ctx.params.rentalObjectCode
-  // )
+  router.get(
+    '(.*)/applicants/validate-rental-rules/property/:contactCode/:rentalObjectCode',
+    async (ctx) => {
+      const res = await leasingAdapter.validatePropertyRentalRules(
+        ctx.params.contactCode,
+        ctx.params.rentalObjectCode
+      )
 
-  // if (!res.ok) {
-  // ctx.status = 500
-  // return
-  // }
+      if (!res.ok) {
+        if (res.err === 'not-tenant-in-the-property') {
+          ctx.status = 403
+          return
+        } else {
+          ctx.status = 500
+          return
+        }
+      }
 
-  // ctx.status = 200
-  // ctx.body = {
-  // data: res.data,
-  // }
-  // }
-  // )
+      ctx.status = 200
+      ctx.body = {
+        data: res.data,
+      }
+    }
+  )
 
-  // router.get(
-  // '(.*)/applicants/validate-rental-rules/residential-area/:contactCode/:districtCode',
-  // async (ctx) => {
-  // const res = await leasingAdapter.validateResidentialAreaRentalRules(
-  // ctx.params.contactCode,
-  // ctx.params.districtCode
-  // )
+  router.get(
+    '(.*)/applicants/validate-rental-rules/residential-area/:contactCode/:districtCode',
+    async (ctx) => {
+      const res = await leasingAdapter.validateResidentialAreaRentalRules(
+        ctx.params.contactCode,
+        ctx.params.districtCode
+      )
 
-  // if (!res.ok) {
-  // ctx.status = 500
-  // return
-  // }
+      if (!res.ok) {
+        if (res.err === 'no-housing-contract-in-the-area') {
+          ctx.status = 403
+          return
+        } else {
+          ctx.status = 500
+          return
+        }
+      }
 
-  // ctx.status = 200
-  // ctx.body = {
-  // data: res.data,
-  // }
-  // }
-  // )
+      ctx.status = 200
+      ctx.body = {
+        data: res.data,
+      }
+    }
+  )
 
   /**
    * @swagger

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -362,18 +362,21 @@ export const routes = (router: KoaRouter) => {
   })
 
   router.get('(.*)/tenants/contactCode/:contactCode', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
     const res = await leasingAdapter.getTenantByContactCode(
       ctx.params.contactCode
     )
 
     if (!res.ok) {
-      ctx.status = res.err === 'not-found' ? 404 : 500
+      ctx.status = 500
+      ctx.body = { error: 'Internal server error', ...metadata }
       return
     }
 
     ctx.status = 200
     ctx.body = {
-      data: res.data,
+      content: res.data,
+      ...metadata,
     }
   })
 

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -619,10 +619,7 @@ export const routes = (router: KoaRouter) => {
    *               type: object
    *               properties:
    *                 applicationType: string
-   *                 example: Additional - applicant is eligible for applying
-   *                 for an additional parking space. Replace - applicant is
-   *                 eligible for replacing their current parking space in the
-   *                 same residential area or property.
+   *                 example: Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property.
    *                 reason:
    *                   type: string
    *                   example: No property rental rules applies to this property.
@@ -718,7 +715,7 @@ export const routes = (router: KoaRouter) => {
   )
   /**
    * @swagger
-   * /applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}
+   * /applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}:
    *   get:
    *     summary: Validate residential area rental rules for applicant
    *     description: Validate residential area rental rules for an applicant based on contact code and district code.
@@ -745,10 +742,7 @@ export const routes = (router: KoaRouter) => {
    *               type: object
    *               properties:
    *                 applicationType: string
-   *                 example: Additional - applicant is eligible for applying
-   *                 for an additional parking space. Replace - applicant is
-   *                 eligible for replacing their current parking space in the
-   *                 same residential area or property.
+   *                 example: Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property.
    *                 reason:
    *                   type: string
    *                   examples:

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -7,31 +7,12 @@
  */
 import KoaRouter from '@koa/router'
 import { logger, generateRouteMetadata } from 'onecore-utilities'
-
-import {
-  getLease,
-  getLeasesForPnr,
-  getCreditInformation,
-  getListingByListingId,
-  getListingsWithApplicants,
-  getApplicantsByContactCode,
-  getApplicantByContactCodeAndListingId,
-  getContactForPhoneNumber,
-  withdrawApplicantByManager,
-  withdrawApplicantByUser,
-  getApplicantsAndListingByContactCode,
-  getListingByIdWithDetailedApplicants,
-  getOffersForContact,
-  getContactsDataBySearchQuery,
-  getContactByContactCode,
-  getContactForPnr,
-  getOfferByContactCodeAndOfferId,
-} from '../../adapters/leasing-adapter'
+import * as leasingAdapter from '../../adapters/leasing-adapter'
 import { ProcessStatus } from '../../common/types'
 import { createOfferForInternalParkingSpace } from '../../processes/parkingspaces/internal'
 
 const getLeaseWithRelatedEntities = async (rentalId: string) => {
-  const lease = await getLease(rentalId, 'true')
+  const lease = await leasingAdapter.getLease(rentalId, 'true')
 
   return lease
 }
@@ -39,7 +20,7 @@ const getLeaseWithRelatedEntities = async (rentalId: string) => {
 const getLeasesWithRelatedEntitiesForPnr = async (
   nationalRegistrationNumber: string
 ) => {
-  const leases = await getLeasesForPnr(
+  const leases = await leasingAdapter.getLeasesForPnr(
     nationalRegistrationNumber,
     undefined,
     'true'
@@ -130,7 +111,9 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('(.*)/cas/getConsumerReport/:pnr', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await getCreditInformation(ctx.params.pnr)
+    const responseData = await leasingAdapter.getCreditInformation(
+      ctx.params.pnr
+    )
 
     ctx.body = {
       content: responseData,
@@ -165,7 +148,7 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('(.*)/contact/:pnr', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await getContactForPnr(ctx.params.pnr)
+    const responseData = await leasingAdapter.getContactForPnr(ctx.params.pnr)
 
     ctx.body = {
       content: responseData,
@@ -205,8 +188,7 @@ export const routes = (router: KoaRouter) => {
 
   router.get('(.*)/contacts/:contactCode/offers', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const res = await getOffersForContact(ctx.params.contactCode)
-
+    const res = await leasingAdapter.getOffersForContact(ctx.params.contactCode)
     if (!res.ok) {
       if (res.err === 'not-found') {
         ctx.status = 404
@@ -264,7 +246,7 @@ export const routes = (router: KoaRouter) => {
 
   router.get('(.*)/offers/:offerId/applicants/:contactCode', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const res = await getOfferByContactCodeAndOfferId(
+    const res = await leasingAdapter.getOfferByContactCodeAndOfferId(
       ctx.params.contactCode,
       ctx.params.offerId
     )
@@ -318,7 +300,7 @@ export const routes = (router: KoaRouter) => {
       return
     }
 
-    const res = await getContactsDataBySearchQuery(ctx.query.q)
+    const res = await leasingAdapter.getContactsDataBySearchQuery(ctx.query.q)
 
     if (!res.ok) {
       ctx.status = 500
@@ -356,7 +338,10 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('(.*)/contact/contactCode/:contactCode', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const res = await getContactByContactCode(ctx.params.contactCode)
+    const res = await leasingAdapter.getContactByContactCode(
+      ctx.params.contactCode
+    )
+
     if (!res.ok) {
       if (res.err === 'not-found') {
         ctx.status = 404
@@ -403,7 +388,9 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('(.*)/contact/phoneNumber/:pnr', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await getContactForPhoneNumber(ctx.params.pnr)
+    const responseData = await leasingAdapter.getContactForPhoneNumber(
+      ctx.params.pnr
+    )
 
     ctx.body = {
       content: responseData,
@@ -476,7 +463,9 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('(.*)/listing/:id', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await getListingByListingId(ctx.params.id)
+    const responseData = await leasingAdapter.getListingByListingId(
+      ctx.params.id
+    )
 
     ctx.body = { content: responseData, ...metadata }
   })
@@ -505,7 +494,7 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('/listings-with-applicants', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await getListingsWithApplicants()
+    const responseData = await leasingAdapter.getListingsWithApplicants()
 
     ctx.body = { content: responseData, ...metadata }
   })
@@ -579,7 +568,7 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('/applicants/:contactCode', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await getApplicantsByContactCode(
+    const responseData = await leasingAdapter.getApplicantsByContactCode(
       ctx.params.contactCode
     )
 
@@ -613,9 +602,10 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('/applicants-with-listings/:contactCode', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await getApplicantsAndListingByContactCode(
-      ctx.params.contactCode
-    )
+    const responseData =
+      await leasingAdapter.getApplicantsAndListingByContactCode(
+        ctx.params.contactCode
+      )
 
     ctx.body = { content: responseData, ...metadata }
   })
@@ -647,9 +637,10 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('/listing/:listingId/applicants/details', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await getListingByIdWithDetailedApplicants(
-      ctx.params.listingId
-    )
+    const responseData =
+      await leasingAdapter.getListingByIdWithDetailedApplicants(
+        ctx.params.listingId
+      )
 
     ctx.body = { content: responseData, ...metadata }
   })
@@ -688,10 +679,11 @@ export const routes = (router: KoaRouter) => {
   router.get('/applicants/:contactCode/:listingId', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
     const { contactCode, listingId } = ctx.params
-    const responseData = await getApplicantByContactCodeAndListingId(
-      contactCode,
-      listingId
-    )
+    const responseData =
+      await leasingAdapter.getApplicantByContactCodeAndListingId(
+        contactCode,
+        listingId
+      )
 
     ctx.body = { content: responseData, ...metadata }
   })
@@ -737,9 +729,10 @@ export const routes = (router: KoaRouter) => {
    */
   router.delete('/applicants/:applicantId/by-manager', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await withdrawApplicantByManager(
+    const responseData = await leasingAdapter.withdrawApplicantByManager(
       ctx.params.applicantId
     )
+
     if (responseData.error) {
       ctx.status = 500 // Internal Server Error
       ctx.body = { error: responseData.error, ...metadata }
@@ -801,10 +794,11 @@ export const routes = (router: KoaRouter) => {
     '/applicants/:applicantId/by-user/:contactCode',
     async (ctx) => {
       const metadata = generateRouteMetadata(ctx)
-      const responseData = await withdrawApplicantByUser(
+      const responseData = await leasingAdapter.withdrawApplicantByUser(
         ctx.params.applicantId,
         ctx.params.contactCode
       )
+
       if (responseData.error) {
         ctx.status = 500 // Internal Server Error
         ctx.body = { error: responseData.error, ...metadata }

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -361,7 +361,7 @@ export const routes = (router: KoaRouter) => {
     }
   })
 
-  router.get('(.*)/tenant/contactCode/:contactCode', async (ctx) => {
+  router.get('(.*)/tenants/contactCode/:contactCode', async (ctx) => {
     const res = await leasingAdapter.getTenantByContactCode(
       ctx.params.contactCode
     )


### PR DESCRIPTION
- Adds public endpoints for property and residential area rental rules validation
- Gathers some adapter imports under `import * as ...` instead for easy domain association and tidyness