### PR TITLE
MIM-115: call close by deny and restart offer in deny offer

### DIFF
--- a/src/adapters/leasing-adapter.ts
+++ b/src/adapters/leasing-adapter.ts
@@ -767,6 +767,24 @@ async function closeOfferByAccept(
   return { ok: false, err: 'unknown' }
 }
 
+async function closeOfferByDeny(
+  offerId: number
+): Promise<AdapterResult<null, 'offer-not-found' | 'unknown'>> {
+  const res = await axios.put(
+    `${tenantsLeasesServiceUrl}/offers/${offerId}/deny`
+  )
+
+  if (res.status === 200) {
+    return { ok: true, data: null }
+  }
+
+  if (res.status === 404) {
+    return { ok: false, err: 'offer-not-found' }
+  }
+
+  return { ok: false, err: 'unknown' }
+}
+
 export {
   getLease,
   getLeasesForPnr,
@@ -806,4 +824,5 @@ export {
   deleteListing,
   closeOfferByAccept,
   getOffersByListingId,
+  closeOfferByDeny,
 }

--- a/src/adapters/leasing-adapter.ts
+++ b/src/adapters/leasing-adapter.ts
@@ -342,7 +342,7 @@ const applyForListing = async (
 }
 
 const getListingByListingId = async (
-  listingId: string
+  listingId: number
 ): Promise<Listing | undefined> => {
   try {
     const result = await axios.get(
@@ -411,9 +411,7 @@ const getApplicantsAndListingByContactCode = async (
       contactCode
     )) as Applicant[]
     for (const applicant of applicantsResponse) {
-      const listingResponse = await getListingByListingId(
-        applicant.listingId.toString()
-      )
+      const listingResponse = await getListingByListingId(applicant.listingId)
       if (listingResponse) {
         applicantsAndListings.push({ applicant, listing: listingResponse })
       }

--- a/src/processes/parkingspaces/internal/create-offer.ts
+++ b/src/processes/parkingspaces/internal/create-offer.ts
@@ -18,7 +18,7 @@ type CreateOfferError =
   | 'unknown'
 
 export const createOfferForInternalParkingSpace = async (
-  listingId: string
+  listingId: number
 ): Promise<ProcessResult<null, CreateOfferError>> => {
   const log: string[] = [
     `Skapa erbjudande för intern bilplats`,

--- a/src/processes/parkingspaces/internal/reply-to-offer.ts
+++ b/src/processes/parkingspaces/internal/reply-to-offer.ts
@@ -7,7 +7,6 @@ import * as communicationAdapter from '../../../adapters/communication-adapter'
 import { makeProcessError } from '../utils'
 import * as propertyManagementAdapter from '../../../adapters/property-management-adapter'
 import { AdapterResult } from '../../../adapters/types'
-import { createOfferForInternalParkingSpace } from './create-offer'
 
 type ReplyToOfferError =
   | 'no-offer'
@@ -149,7 +148,7 @@ export const acceptOffer = async (
 
 export const denyOffer = async (
   offerId: number
-): Promise<ProcessResult<null, ReplyToOfferError>> => {
+): Promise<ProcessResult<{ listingId: number }, ReplyToOfferError>> => {
   try {
     //Get offer
     const res = await leasingAdapter.getOfferByOfferId(offerId)
@@ -177,12 +176,10 @@ export const denyOffer = async (
       })
     }
 
-    const _createOffer = createOfferForInternalParkingSpace(offer.listingId)
-
     return {
       processStatus: ProcessStatus.successful,
       httpStatus: 202,
-      data: null,
+      data: { listingId: listing.id },
     }
   } catch (err) {
     return makeProcessError('unknown', 500)

--- a/src/processes/parkingspaces/internal/reply-to-offer.ts
+++ b/src/processes/parkingspaces/internal/reply-to-offer.ts
@@ -178,7 +178,7 @@ export const denyOffer = async (
     }
 
     const _createOffer = createOfferForInternalParkingSpace(
-      offer.rentalObjectCode
+      offer.listingId.toString()
     )
 
     return {

--- a/src/processes/parkingspaces/internal/reply-to-offer.ts
+++ b/src/processes/parkingspaces/internal/reply-to-offer.ts
@@ -177,9 +177,7 @@ export const denyOffer = async (
       })
     }
 
-    const _createOffer = createOfferForInternalParkingSpace(
-      offer.listingId.toString()
-    )
+    const _createOffer = createOfferForInternalParkingSpace(offer.listingId)
 
     return {
       processStatus: ProcessStatus.successful,

--- a/src/processes/parkingspaces/internal/tests/create-offer.test.ts
+++ b/src/processes/parkingspaces/internal/tests/create-offer.test.ts
@@ -16,7 +16,7 @@ describe('createOfferForInternalParkingSpace', () => {
       .spyOn(leasingAdapter, 'getListingByListingId')
       .mockResolvedValueOnce(undefined)
 
-    const result = await createOfferForInternalParkingSpace('123')
+    const result = await createOfferForInternalParkingSpace(123)
 
     expect(result).toEqual({
       processStatus: ProcessStatus.failed,
@@ -32,7 +32,7 @@ describe('createOfferForInternalParkingSpace', () => {
         factory.listing.build({ status: ListingStatus.Active })
       )
 
-    const result = await createOfferForInternalParkingSpace('123')
+    const result = await createOfferForInternalParkingSpace(123)
 
     expect(result).toEqual({
       processStatus: ProcessStatus.failed,
@@ -51,7 +51,7 @@ describe('createOfferForInternalParkingSpace', () => {
       .spyOn(leasingAdapter, 'getListingByIdWithDetailedApplicants')
       .mockResolvedValueOnce([])
 
-    const result = await createOfferForInternalParkingSpace('123')
+    const result = await createOfferForInternalParkingSpace(123)
 
     expect(result).toEqual({
       processStatus: ProcessStatus.failed,
@@ -101,7 +101,7 @@ describe('createOfferForInternalParkingSpace', () => {
       .spyOn(leasingAdapter, 'createOffer')
       .mockResolvedValueOnce(factory.offer.build())
 
-    const result = await createOfferForInternalParkingSpace('123')
+    const result = await createOfferForInternalParkingSpace(123)
 
     expect(leasingAdapter.updateApplicantStatus).toHaveBeenCalledWith({
       applicantId: 432,
@@ -133,7 +133,7 @@ describe('createOfferForInternalParkingSpace', () => {
       .spyOn(leasingAdapter, 'getContact')
       .mockResolvedValueOnce({ ok: false, err: 'unknown' })
 
-    const result = await createOfferForInternalParkingSpace('123')
+    const result = await createOfferForInternalParkingSpace(123)
 
     expect(result).toEqual({
       processStatus: ProcessStatus.failed,
@@ -158,7 +158,7 @@ describe('createOfferForInternalParkingSpace', () => {
       .spyOn(leasingAdapter, 'updateApplicantStatus')
       .mockRejectedValueOnce(null)
 
-    const result = await createOfferForInternalParkingSpace('123')
+    const result = await createOfferForInternalParkingSpace(123)
 
     expect(result).toEqual({
       processStatus: ProcessStatus.failed,
@@ -184,7 +184,7 @@ describe('createOfferForInternalParkingSpace', () => {
       .mockResolvedValueOnce(null)
     jest.spyOn(leasingAdapter, 'createOffer').mockRejectedValueOnce(null)
 
-    const result = await createOfferForInternalParkingSpace('123')
+    const result = await createOfferForInternalParkingSpace(123)
 
     expect(result).toEqual({
       processStatus: ProcessStatus.failed,
@@ -217,7 +217,7 @@ describe('createOfferForInternalParkingSpace', () => {
       .spyOn(leasingAdapter, 'createOffer')
       .mockResolvedValueOnce(factory.offer.build())
 
-    const result = await createOfferForInternalParkingSpace('123')
+    const result = await createOfferForInternalParkingSpace(123)
 
     expect(result).toEqual({
       processStatus: ProcessStatus.successful,

--- a/src/processes/parkingspaces/internal/tests/reply-to-offer.test.ts
+++ b/src/processes/parkingspaces/internal/tests/reply-to-offer.test.ts
@@ -316,30 +316,6 @@ describe('replyToOffer', () => {
         },
       })
     })
-
-    it('calls create offer to restart the process', async () => {
-      const closeOfferSpy = jest.spyOn(leasingAdapter, 'closeOfferByDeny')
-      getOfferByIdSpy.mockResolvedValueOnce({
-        ok: true,
-        data: factory.detailedOffer.build(),
-      })
-      getPublishedParkingSpaceSpy.mockResolvedValueOnce(factory.listing.build())
-      closeOfferSpy.mockResolvedValueOnce({ ok: true, data: null })
-
-      const createOfferProcess = jest
-        .spyOn(createProcess, 'createOfferForInternalParkingSpace')
-        .mockResolvedValueOnce({
-          processStatus: ProcessStatus.successful,
-        } as ProcessResult)
-
-      const result = await replyProcesses.denyOffer(123)
-
-      expect(result).toMatchObject({
-        processStatus: ProcessStatus.successful,
-      })
-      expect(createOfferProcess).toHaveBeenCalledTimes(1)
-      createOfferProcess.mockRestore()
-    })
   })
 
   describe('expireOffer', () => {

--- a/src/processes/parkingspaces/internal/tests/reply-to-offer.test.ts
+++ b/src/processes/parkingspaces/internal/tests/reply-to-offer.test.ts
@@ -6,7 +6,6 @@ import { OfferStatus } from 'onecore-types'
 
 import { ProcessResult, ProcessStatus } from '../../../../common/types'
 import * as replyProcesses from '../reply-to-offer'
-import * as createProcess from '../create-offer'
 import * as factory from '../../../../../test/factories'
 
 describe('replyToOffer', () => {
@@ -149,7 +148,7 @@ describe('replyToOffer', () => {
         err: 'not-in-waiting-list',
       })
 
-      const result = await processes.acceptOffer(123)
+      const result = await replyProcesses.acceptOffer(123)
 
       expect(result).toEqual({
         processStatus: ProcessStatus.successful,
@@ -170,7 +169,7 @@ describe('replyToOffer', () => {
         throw new Error('Lease not created')
       })
 
-      const result = await processes.acceptOffer(offer.id)
+      const result = await replyProcesses.acceptOffer(offer.id)
 
       expect(result).toEqual({
         processStatus: ProcessStatus.failed,
@@ -210,7 +209,7 @@ describe('replyToOffer', () => {
         throw new Error('Email not sent')
       })
 
-      const result = await processes.acceptOffer(123)
+      const result = await replyProcesses.acceptOffer(123)
 
       expect(result).toEqual({
         processStatus: ProcessStatus.successful,
@@ -250,7 +249,6 @@ describe('replyToOffer', () => {
 
       const result = await replyProcesses.acceptOffer(123)
 
-      console.log('result', result)
       expect(result).toMatchObject({
         processStatus: ProcessStatus.successful,
       })
@@ -292,27 +290,6 @@ describe('replyToOffer', () => {
         httpStatus: 404,
         response: {
           message: `The parking space ${offer.listingId} does not exist or is no longer available.`,
-        },
-      })
-    })
-
-    it('returns a process error if close offer fails', async () => {
-      const closeOfferSpy = jest.spyOn(leasingAdapter, 'closeOfferByDeny')
-      getOfferByIdSpy.mockResolvedValueOnce({
-        ok: true,
-        data: factory.detailedOffer.build(),
-      })
-      getPublishedParkingSpaceSpy.mockResolvedValueOnce(factory.listing.build())
-      closeOfferSpy.mockResolvedValueOnce({ ok: false, err: 'unknown' })
-
-      const result = await replyProcesses.denyOffer(123)
-
-      expect(result).toEqual({
-        processStatus: ProcessStatus.failed,
-        error: 'close-offer',
-        httpStatus: 500,
-        response: {
-          message: 'Something went wrong when closing the offer.',
         },
       })
     })

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -529,7 +529,7 @@ export const routes = (router: KoaRouter) => {
   router.get('(.*)/listing/:id', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
     const responseData = await leasingAdapter.getListingByListingId(
-      ctx.params.id
+      Number.parseInt(ctx.params.id)
     )
 
     ctx.body = { content: responseData, ...metadata }
@@ -597,7 +597,7 @@ export const routes = (router: KoaRouter) => {
   router.post('(.*)/listings/:listingId/offers', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
     const result = await createOfferForInternalParkingSpace(
-      ctx.params.listingId
+      Number.parseInt(ctx.params.listingId)
     )
 
     if (result.processStatus === ProcessStatus.successful) {

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -10,12 +10,7 @@ import { logger, generateRouteMetadata } from 'onecore-utilities'
 
 import * as leasingAdapter from '../../adapters/leasing-adapter'
 import { ProcessStatus } from '../../common/types'
-import {
-  createOfferForInternalParkingSpace,
-  acceptOffer,
-  denyOffer,
-  expireOffer,
-} from '../../processes/parkingspaces/internal'
+import * as internalParkingSpaceProcesses from '../../processes/parkingspaces/internal'
 
 const getLeaseWithRelatedEntities = async (rentalId: string) => {
   const lease = await leasingAdapter.getLease(rentalId, 'true')
@@ -596,9 +591,10 @@ export const routes = (router: KoaRouter) => {
    */
   router.post('(.*)/listings/:listingId/offers', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const result = await createOfferForInternalParkingSpace(
-      Number.parseInt(ctx.params.listingId)
-    )
+    const result =
+      await internalParkingSpaceProcesses.createOfferForInternalParkingSpace(
+        Number.parseInt(ctx.params.listingId)
+      )
 
     if (result.processStatus === ProcessStatus.successful) {
       logger.info(result)
@@ -638,7 +634,9 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('(.*)/offers/:offerId/accept', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const result = await acceptOffer(parseInt(ctx.params.offerId))
+    const result = await internalParkingSpaceProcesses.acceptOffer(
+      parseInt(ctx.params.offerId)
+    )
 
     if (result.processStatus === ProcessStatus.successful) {
       logger.info(result)
@@ -676,17 +674,23 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('(.*)/offers/:offerId/deny', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const result = await denyOffer(parseInt(ctx.params.offerId))
+    const denyOffer = await internalParkingSpaceProcesses.denyOffer(
+      Number.parseInt(ctx.params.offerId)
+    )
 
-    if (result.processStatus === ProcessStatus.successful) {
-      logger.info(result)
-      ctx.status = 202
-      ctx.body = { message: 'Offer denied successfully', ...metadata }
+    if (denyOffer.processStatus !== ProcessStatus.successful) {
+      ctx.status = 500
+      ctx.body = { error: denyOffer.error, ...metadata }
       return
     }
 
-    ctx.status = 500
-    ctx.body = { error: result.error, ...metadata }
+    const _createOffer =
+      await internalParkingSpaceProcesses.createOfferForInternalParkingSpace(
+        denyOffer.data.listingId
+      )
+
+    ctx.status = 202
+    ctx.body = { message: 'Offer denied successfully', ...metadata }
   })
 
   /**
@@ -714,7 +718,9 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('(.*)/offers/:offerId/expire', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const result = await expireOffer(parseInt(ctx.params.offerId))
+    const result = await internalParkingSpaceProcesses.expireOffer(
+      parseInt(ctx.params.offerId)
+    )
 
     if (result.processStatus === ProcessStatus.successful) {
       logger.info(result)

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -274,7 +274,7 @@ describe('lease-service', () => {
       jest.spyOn(replyToOffer, 'denyOffer').mockResolvedValueOnce({
         processStatus: ProcessStatus.successful,
         httpStatus: 202,
-        data: null,
+        data: { listingId: 123 },
       })
 
       const result = await request(app.callback()).get('/offers/123/deny')


### PR DESCRIPTION
- Call close by deny 
- Call create offer


I'm not sure I like the way the processes are calling each other... feels like it could easily get confusing.

AcceptOffer will call DenyOffer and DenyOffer will call CreateOffer 😅 

I'd rather have some "outer function" calling them all, something like:
```ts
const acceptResult = process.acceptOffer(..)
const otherOffers = getOtherOffers(contact)
for each otherOffers
  process.denyOffer(offer.id)
  then
  process.createOffer(offer.id)
 
```

**update**
Extracted the process<-> process calls and put them all in the endpoint for this route (deny offer)