### PR TITLE
Remove getContact and replace with getContactByContactCode

### DIFF
--- a/src/adapters/leasing-adapter/index.ts
+++ b/src/adapters/leasing-adapter/index.ts
@@ -104,28 +104,6 @@ const getContactsDataBySearchQuery = async (
   }
 }
 
-const getContact = async (
-  contactCode: string
-): Promise<AdapterResult<Contact, 'not-found' | 'unknown'>> => {
-  try {
-    const res = await axios<{ content?: Contact }>(
-      tenantsLeasesServiceUrl + '/contact/contactCode/' + contactCode
-    )
-
-    if (res.status === 404) {
-      return { ok: false, err: 'not-found' }
-    }
-
-    if (res.status === 200 && res.data.content) {
-      return { ok: true, data: res.data.content }
-    }
-
-    return { ok: false, err: 'unknown' }
-  } catch (error) {
-    return { ok: false, err: 'unknown' }
-  }
-}
-
 const getContactByContactCode = async (
   contactCode: string
 ): Promise<AdapterResult<Contact, 'not-found' | 'unknown'>> => {
@@ -549,7 +527,6 @@ export {
   getApplicantsAndListingByContactCode,
   getApplicantsByContactCode,
   getApplicationProfileByContactCode,
-  getContact,
   getContactByContactCode,
   getContactByPhoneNumber,
   getContactForPnr,

--- a/src/processes/parkingspaces/external/index.ts
+++ b/src/processes/parkingspaces/external/index.ts
@@ -10,7 +10,7 @@ import {
 } from 'onecore-types'
 import {
   createLease,
-  getContact,
+  getContactByContactCode,
   getCreditInformation,
   getInternalCreditInformation,
 } from '../../../adapters/leasing-adapter'
@@ -74,7 +74,7 @@ export const createLeaseForExternalParkingSpace = async (
     }
 
     // Step 2. Get information about applicant and contracts
-    const applicantResult = await getContact(contactId)
+    const applicantResult = await getContactByContactCode(contactId)
 
     if (!applicantResult.ok) {
       return {

--- a/src/processes/parkingspaces/external/tests/index.test.ts
+++ b/src/processes/parkingspaces/external/tests/index.test.ts
@@ -68,7 +68,7 @@ describe('parkingspaces', () => {
         .spyOn(propertyManagementAdapter, 'getParkingSpace')
         .mockResolvedValue(mockedParkingSpace)
       getContactSpy = jest
-        .spyOn(leasingAdapter, 'getContact')
+        .spyOn(leasingAdapter, 'getContactByContactCode')
         .mockResolvedValue({ ok: true, data: mockedApplicantWithoutLeases })
       getCreditInformationSpy = jest
         .spyOn(leasingAdapter, 'getCreditInformation')

--- a/src/processes/parkingspaces/internal/create-note-of-interest.ts
+++ b/src/processes/parkingspaces/internal/create-note-of-interest.ts
@@ -12,7 +12,6 @@ import {
 import { logger } from 'onecore-utilities'
 
 import {
-  getContact,
   getLeasesForPnr,
   addApplicantToWaitingList,
   getActiveListingByRentalObjectCode,
@@ -23,6 +22,7 @@ import {
   getApplicantByContactCodeAndListingId,
   validateResidentialAreaRentalRules,
   validatePropertyRentalRules,
+  getContactByContactCode,
 } from '../../../adapters/leasing-adapter'
 import { getPublishedParkingSpace } from '../../../adapters/property-management-adapter'
 import {
@@ -76,7 +76,7 @@ export const createNoteOfInterestForInternalParkingSpace = async (
     }
 
     // Step 2. Get information about applicant and contracts
-    const getApplicantContact = await getContact(contactCode)
+    const getApplicantContact = await getContactByContactCode(contactCode)
     if (!getApplicantContact.ok) {
       return endFailingProcess(
         log,

--- a/src/processes/parkingspaces/internal/create-offer.ts
+++ b/src/processes/parkingspaces/internal/create-offer.ts
@@ -87,7 +87,9 @@ export const createOfferForInternalParkingSpace = async (
 
     const [applicant, ...restApplicants] = eligibleApplicants
 
-    const getContact = await leasingAdapter.getContact(applicant.contactCode)
+    const getContact = await leasingAdapter.getContactByContactCode(
+      applicant.contactCode
+    )
     if (!getContact.ok) {
       return endFailingProcess(
         log,

--- a/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
+++ b/src/processes/parkingspaces/internal/tests/create-note-of-interest.test.ts
@@ -56,7 +56,7 @@ describe('createNoteOfInterestForInternalParkingSpace', () => {
   })
 
   const getContactSpy = jest
-    .spyOn(leasingAdapter, 'getContact')
+    .spyOn(leasingAdapter, 'getContactByContactCode')
     .mockResolvedValue({ ok: true, data: mockedContact })
   const getLeasesForPnrSpy = jest
     .spyOn(leasingAdapter, 'getLeasesForPnr')

--- a/src/processes/parkingspaces/internal/tests/create-offer.test.ts
+++ b/src/processes/parkingspaces/internal/tests/create-offer.test.ts
@@ -142,7 +142,7 @@ describe('createOfferForInternalParkingSpace', () => {
       .spyOn(leasingAdapter, 'getDetailedApplicantsByListingId')
       .mockResolvedValueOnce({ ok: true, data: applicants })
     jest
-      .spyOn(leasingAdapter, 'getContact')
+      .spyOn(leasingAdapter, 'getContactByContactCode')
       .mockResolvedValueOnce({ ok: true, data: factory.contact.build() })
     jest
       .spyOn(leasingAdapter, 'updateApplicantStatus')
@@ -186,7 +186,7 @@ describe('createOfferForInternalParkingSpace', () => {
         data: factory.detailedApplicant.buildList(1),
       })
     jest
-      .spyOn(leasingAdapter, 'getContact')
+      .spyOn(leasingAdapter, 'getContactByContactCode')
       .mockResolvedValueOnce({ ok: false, err: 'unknown' })
 
     const result = await createOfferForInternalParkingSpace(123)
@@ -215,7 +215,7 @@ describe('createOfferForInternalParkingSpace', () => {
         data: factory.detailedApplicant.buildList(1),
       })
     jest
-      .spyOn(leasingAdapter, 'getContact')
+      .spyOn(leasingAdapter, 'getContactByContactCode')
       .mockResolvedValueOnce({ ok: true, data: factory.contact.build() })
     jest
       .spyOn(leasingAdapter, 'updateApplicantStatus')
@@ -247,7 +247,7 @@ describe('createOfferForInternalParkingSpace', () => {
         data: factory.detailedApplicant.buildList(1),
       })
     jest
-      .spyOn(leasingAdapter, 'getContact')
+      .spyOn(leasingAdapter, 'getContactByContactCode')
       .mockResolvedValueOnce({ ok: true, data: factory.contact.build() })
     jest
       .spyOn(leasingAdapter, 'updateApplicantStatus')
@@ -282,7 +282,7 @@ describe('createOfferForInternalParkingSpace', () => {
         data: factory.detailedApplicant.buildList(1),
       })
     jest
-      .spyOn(leasingAdapter, 'getContact')
+      .spyOn(leasingAdapter, 'getContactByContactCode')
       .mockResolvedValueOnce({ ok: true, data: factory.contact.build() })
     jest
       .spyOn(leasingAdapter, 'updateApplicantStatus')

--- a/src/services/ticketing-service/index.ts
+++ b/src/services/ticketing-service/index.ts
@@ -1,6 +1,5 @@
 import KoaRouter from '@koa/router'
 import {
-  getContact,
   getContactByContactCode,
   getContactByPhoneNumber,
   getLease,
@@ -415,7 +414,9 @@ export const routes = (router: KoaRouter) => {
   router.get('(.*)/maintenanceUnitsByContactCode/:contactCode', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
     try {
-      const contactResult = await getContact(ctx.params.contactCode)
+      const contactResult = await getContactByContactCode(
+        ctx.params.contactCode
+      )
       if (!contactResult.ok) {
         ctx.status = 404
         ctx.body = { reason: 'Contact not found', ...metadata }

--- a/src/services/ticketing-service/tests/index.test.ts
+++ b/src/services/ticketing-service/tests/index.test.ts
@@ -313,7 +313,7 @@ describe('ticketing-service index', () => {
 
     it('should return all maintenance units', async () => {
       const getContactSpy = jest
-        .spyOn(tenantLeaseAdapter, 'getContact')
+        .spyOn(tenantLeaseAdapter, 'getContactByContactCode')
         .mockResolvedValue({ ok: true, data: contactMockData })
       const getLeasesForPnrSpy = jest
         .spyOn(tenantLeaseAdapter, 'getLeasesForPnr')


### PR DESCRIPTION
`getContact` and `getContactByContactCode` in `leasing-adapter` are basically identical. This PR removes `getContact` and replaces it with `getContactByContactCode` where it was being used.