### PR TITLE
Feat:UTH-38 Get Waiting Lists from XPand-DB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "koa-pino-logger": "^4.0.0",
         "koa2-swagger-ui": "^5.10.0",
         "odoo-await": "^3.4.1",
-        "onecore-types": "^1.34.0",
+        "onecore-types": "^1.34.1",
         "onecore-utilities": "^1.1.0",
         "pino": "^9.1.0",
         "pino-elasticsearch": "^8.0.0",
@@ -7530,9 +7530,9 @@
       }
     },
     "node_modules/onecore-types": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.34.0.tgz",
-      "integrity": "sha512-EXV8NgDuhbJ1EdJtNhEpJIoHepcl2fcJvbJiuNA48Oot0cul536ppp6W9R1iMCogP0TVNGLmRnU//PzC4pCRNw==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.34.1.tgz",
+      "integrity": "sha512-Vs4cyXlpi3n+7+NYCaRy+dnSjxoSHs5tC1OGAC3kbbMB0FJQ9tkJINSChOV5HzAqWpbUswGdUkgCn5vaYUAtdg==",
       "license": "ISC",
       "dependencies": {
         "release-please": "^16.8.0"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "koa-pino-logger": "^4.0.0",
     "koa2-swagger-ui": "^5.10.0",
     "odoo-await": "^3.4.1",
-    "onecore-types": "^1.34.0",
+    "onecore-types": "^1.34.1",
     "onecore-utilities": "^1.1.0",
     "pino": "^9.1.0",
     "pino-elasticsearch": "^8.0.0",

--- a/src/adapters/leasing-adapter.ts
+++ b/src/adapters/leasing-adapter.ts
@@ -7,7 +7,6 @@ import {
   Invoice,
   InvoiceTransactionType,
   Lease,
-  WaitingList,
   Listing,
   Applicant,
   ApplicantStatus,
@@ -20,6 +19,7 @@ import {
   InternalParkingSpaceSyncSuccessResponse,
   CreateOfferParams,
   OfferWithOfferApplicants,
+  WaitingListType,
 } from 'onecore-types'
 
 import config from '../common/config'
@@ -234,33 +234,21 @@ const getInternalCreditInformation = async (
   return !hasDebtCollection
 }
 
-const getWaitingList = async (
-  nationalRegistrationNumber: string
-): Promise<WaitingList[]> => {
-  const response = await axios(
-    tenantsLeasesServiceUrl +
-      '/contact/waitingList/' +
-      nationalRegistrationNumber
-  )
-  return response.data.content
-}
-
 const addApplicantToWaitingList = async (
   nationalRegistrationNumber: string,
   contactCode: string,
-  waitingListTypeCaption: string
+  waitingListType: WaitingListType
 ) => {
   const axiosOptions = {
     method: 'POST',
     data: {
       contactCode: contactCode,
-      waitingListTypeCaption: waitingListTypeCaption,
+      waitingListType: waitingListType,
     },
   }
   return await axios(
     tenantsLeasesServiceUrl +
-      '/contact/waitingList/' +
-      nationalRegistrationNumber,
+      `/contacts/${nationalRegistrationNumber}/waitingLists`,
     axiosOptions
   )
 }
@@ -268,21 +256,19 @@ const addApplicantToWaitingList = async (
 const resetWaitingList = async (
   nationalRegistrationNumber: string,
   contactCode: string,
-  waitingListTypeCaption: string
+  waitingListType: WaitingListType
 ): Promise<AdapterResult<undefined, 'not-in-waiting-list' | 'unknown'>> => {
   try {
     const axiosOptions = {
       method: 'POST',
       data: {
         contactCode: contactCode,
-        waitingListTypeCaption: waitingListTypeCaption,
+        waitingListType: waitingListType,
       },
     }
     const res = await axios(
       tenantsLeasesServiceUrl +
-        '/contact/waitingList/' +
-        nationalRegistrationNumber +
-        '/reset',
+        `/contacts/${nationalRegistrationNumber}/waitingLists/reset`,
       axiosOptions
     )
 
@@ -804,7 +790,6 @@ export {
   createLease,
   getCreditInformation,
   getInternalCreditInformation,
-  getWaitingList,
   addApplicantToWaitingList,
   resetWaitingList,
   createNewListing,

--- a/src/adapters/tests/leasing-adapter.test.ts
+++ b/src/adapters/tests/leasing-adapter.test.ts
@@ -1,7 +1,7 @@
 import { HttpStatusCode } from 'axios'
 import assert from 'node:assert'
 import nock from 'nock'
-import { OfferStatus } from 'onecore-types'
+import { OfferStatus, WaitingListType } from 'onecore-types'
 
 import config from '../../common/config'
 import * as leasingAdapter from '../leasing-adapter'
@@ -48,26 +48,6 @@ describe('leasing-adapter', () => {
     })
   })
 
-  describe(leasingAdapter.getWaitingList, () => {
-    it('should return waiting list', async () => {
-      const waitingList = factory.waitingList.build()
-      nock(config.tenantsLeasesService.url)
-        .get(/contact\/waitingList\//)
-        .reply(200, { content: [waitingList] })
-
-      const result = await leasingAdapter.getWaitingList('P123456')
-
-      expect(result).toEqual([
-        {
-          ...waitingList,
-          contractFromApartment:
-            waitingList.contractFromApartment.toISOString(),
-          waitingListFrom: waitingList.waitingListFrom.toISOString(),
-        },
-      ])
-    })
-  })
-
   describe(leasingAdapter.getListingByIdWithDetailedApplicants, () => {
     it('should return a listing with detailed applicants', async () => {
       const detailedApplicants = factory.detailedApplicant.buildList(1)
@@ -87,13 +67,13 @@ describe('leasing-adapter', () => {
   describe(leasingAdapter.addApplicantToWaitingList, () => {
     it('should add applicant to waiting list', async () => {
       nock(config.tenantsLeasesService.url)
-        .post(/contact\/waitingList/)
+        .post(/contacts\/196709226789\/waitingLists/)
         .reply(201)
 
       const result = await leasingAdapter.addApplicantToWaitingList(
-        '´196709226789',
+        '196709226789',
         'P123456',
-        'Bilplats (intern)'
+        WaitingListType.ParkingSpace
       )
 
       expect(result.status).toEqual(HttpStatusCode.Created)
@@ -103,13 +83,13 @@ describe('leasing-adapter', () => {
   describe(leasingAdapter.resetWaitingList, () => {
     it('should reset waiting list for applicant', async () => {
       nock(config.tenantsLeasesService.url)
-        .post(/contact\/waitingList/)
+        .post(/contacts\/196709226789\/waitingLists/)
         .reply(200)
 
       const result = await leasingAdapter.resetWaitingList(
-        '´196709226789',
+        '196709226789',
         'P123456',
-        'Bilplats (intern)'
+        WaitingListType.ParkingSpace
       )
 
       expect(result.ok).toEqual(true)
@@ -117,13 +97,13 @@ describe('leasing-adapter', () => {
 
     it('should return not-in-waiting-list when applicant not in waiting list', async () => {
       nock(config.tenantsLeasesService.url)
-        .post(/contact\/waitingList/)
+        .post(/contacts\/196709226789\/waitingLists/)
         .reply(404)
 
       const result = await leasingAdapter.resetWaitingList(
-        '´196709226789',
+        '196709226789',
         'P123456',
-        'Bilplats (intern)'
+        WaitingListType.ParkingSpace
       )
 
       expect(result.ok).toEqual(false)
@@ -132,13 +112,13 @@ describe('leasing-adapter', () => {
 
     it('should return unknown on unknown error from leasing', async () => {
       nock(config.tenantsLeasesService.url)
-        .post(/contact\/waitingList/)
+        .post(/contacts\/196709226789\/waitingLists/)
         .reply(500)
 
       const result = await leasingAdapter.resetWaitingList(
-        '´196709226789',
+        '196709226789',
         'P123456',
-        'Bilplats (intern)'
+        WaitingListType.ParkingSpace
       )
 
       expect(result.ok).toEqual(false)

--- a/src/processes/parkingspaces/internal/reply-to-offer.ts
+++ b/src/processes/parkingspaces/internal/reply-to-offer.ts
@@ -3,6 +3,7 @@ import {
   OfferStatus,
   OfferWithRentalObjectCode,
   ReplyToOfferErrorCodes,
+  WaitingListType,
 } from 'onecore-types'
 import { logger } from 'onecore-utilities'
 
@@ -102,32 +103,17 @@ export const acceptOffer = async (
       )
     }
 
-    //Reset internal waiting list
-    const internalWaitingListResult = await leasingAdapter.resetWaitingList(
+    //Reset waiting list
+    const waitingListResult = await leasingAdapter.resetWaitingList(
       offer.offeredApplicant.nationalRegistrationNumber,
       offer.offeredApplicant.contactCode,
-      'Bilplats (intern)'
+      WaitingListType.ParkingSpace
     )
-    if (!internalWaitingListResult.ok) {
+    if (!waitingListResult.ok) {
       log.push(
-        'Kunde inte återställa köpoäng för interna bilplatser: ' +
-          internalWaitingListResult.err
+        'Kunde inte återställa köpoäng för bilplatser: ' + waitingListResult.err
       )
-      logger.error(internalWaitingListResult.err)
-    }
-
-    //Reset external waiting list
-    const externalWaitingListResult = await leasingAdapter.resetWaitingList(
-      offer.offeredApplicant.nationalRegistrationNumber,
-      offer.offeredApplicant.contactCode,
-      'Bilplats (extern)'
-    )
-    if (!externalWaitingListResult.ok) {
-      log.push(
-        'Kunde inte återställa köpoäng för externa bilplatser: ' +
-          externalWaitingListResult.err
-      )
-      logger.error(externalWaitingListResult.err)
+      logger.error(waitingListResult.err)
     }
 
     //Deny other offers for this contact

--- a/test/factories/waiting-list.ts
+++ b/test/factories/waiting-list.ts
@@ -1,14 +1,10 @@
 import { Factory } from 'fishery'
-import { WaitingList } from 'onecore-types'
+import { WaitingList, WaitingListType } from 'onecore-types'
 
 export const WaitingListFactory = Factory.define<WaitingList>(() => {
   return {
-    applicantCaption: 'Foo Bar',
-    contactCode: 'P12345',
-    contractFromApartment: new Date('2024-02-29T23:00:00.000Z'),
     queuePoints: 45,
-    queuePointsSocialConnection: 0,
-    waitingListFrom: new Date('2024-01-31T23:00:00.000Z'),
-    waitingListTypeCaption: 'Bostad',
+    queueTime: new Date('2024-01-31T23:00:00.000Z'),
+    type: WaitingListType.ParkingSpace,
   }
 })


### PR DESCRIPTION
* Queue points has been moved from tenant to contact
* Waiting list queue points and other info is now retrieved by getContact instead of a separate GET to leasing
* Logic for internal/external waiting lists is now handled in the leasing service instead