### PR TITLE
UTH-81: Create new offer from within deny process

### DIFF
--- a/src/processes/parkingspaces/internal/create-note-of-interest.ts
+++ b/src/processes/parkingspaces/internal/create-note-of-interest.ts
@@ -323,7 +323,6 @@ export const createNoteOfInterestForInternalParkingSpace = async (
       'Create note of interest for internal parking space failed due to unknown error 1'
     )
   } catch (error: any) {
-    console.log('unknown error', error)
     const errorMessage =
       error instanceof Error
         ? 'Create note of interest for internal parking space failed: ' +

--- a/src/processes/parkingspaces/internal/reply-to-offer.ts
+++ b/src/processes/parkingspaces/internal/reply-to-offer.ts
@@ -16,6 +16,7 @@ import * as leasingAdapter from '../../../adapters/leasing-adapter'
 import * as communicationAdapter from '../../../adapters/communication-adapter'
 import { makeProcessError } from '../utils'
 import { AdapterResult } from '../../../adapters/types'
+import { createOfferForInternalParkingSpace } from './create-offer'
 
 type ReplyToOfferError =
   | ReplyToOfferErrorCodes.NoOffer
@@ -238,6 +239,18 @@ export const denyOffer = async (
         ReplyToOfferErrorCodes.CloseOfferFailure,
         500,
         `Something went wrong when denying the offer ${offer.id}`
+      )
+    }
+
+    log.push('Creating new offer for this listing...')
+    const createOffer = await createOfferForInternalParkingSpace(
+      offer.listingId
+    )
+
+    if (createOffer.processStatus === ProcessStatus.failed) {
+      logger.info(createOffer, 'Could not create new offer for this listing.')
+      log.push(
+        `Could not create new offer for this listing: ${createOffer.error}`
       )
     }
 

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -742,11 +742,6 @@ export const routes = (router: KoaRouter) => {
       return
     }
 
-    //do not await since the process is responsible to handle the new offer
-    internalParkingSpaceProcesses.createOfferForInternalParkingSpace(
-      denyOffer.data.listingId
-    )
-
     ctx.status = 202
     ctx.body = { message: 'Offer denied successfully', ...metadata }
   })

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -275,19 +275,13 @@ describe('lease-service', () => {
         httpStatus: 202,
         data: { listingId: 123 },
       })
-      jest
-        .spyOn(offerProcess, 'createOfferForInternalParkingSpace')
-        .mockResolvedValue({
-          processStatus: ProcessStatus.successful,
-          data: null,
-          httpStatus: 200,
-        })
 
       const result = await request(app.callback()).post('/offers/123/deny')
 
       expect(result.status).toBe(202)
       expect(result.body.message).toBe('Offer denied successfully')
     })
+
     it('deny offer returns 500 on error', async () => {
       jest.spyOn(replyToOffer, 'denyOffer').mockResolvedValue({
         processStatus: ProcessStatus.failed,


### PR DESCRIPTION
Before, the /deny offer route was responsible for 
1. Deny offer for listing
2. Create new offer for listing

This doesn't work because when an offer is accepted, the acceptOffer process calls denyOffer for each of the offered applicants other offers. This means if denyOffer doesn't call createOffer, these denied offers will not be restarted.

Fixes https://linear.app/mimer-onecore/issue/UTH-81/svara-ja-1a-for-andra-erbjudanden-anvandaren-har-sa-ska-anvandaren