### PR TITLE
UTH-125: No parking spaces when getting 'historical'

### DIFF
--- a/src/processes/parkingspaces/internal/reply-to-offer.ts
+++ b/src/processes/parkingspaces/internal/reply-to-offer.ts
@@ -1,5 +1,4 @@
 import {
-  ListingStatus,
   OfferStatus,
   OfferWithRentalObjectCode,
   ReplyToOfferErrorCodes,
@@ -142,21 +141,11 @@ export const acceptOffer = async (
       }
     }
 
-    //Close offer
+    // Closes offer, updates listing and applicant status
     const closeOffer = await leasingAdapter.closeOfferByAccept(offer.id)
     if (!closeOffer.ok) {
       log.push(`Something went wrong when closing the offer ${offer.id}.`)
       logger.error(closeOffer.err)
-    }
-
-    const closeListing = await leasingAdapter.updateListingStatus(
-      listing.id,
-      ListingStatus.Closed
-    )
-
-    if (!closeListing.ok) {
-      log.push(`Something went wrong when closing the listing ${listing.id}.`)
-      logger.error(closeListing.err)
     }
 
     try {

--- a/src/processes/parkingspaces/internal/tests/reply-to-offer.test.ts
+++ b/src/processes/parkingspaces/internal/tests/reply-to-offer.test.ts
@@ -233,17 +233,12 @@ describe('replyToOffer', () => {
           processStatus: ProcessStatus.successful,
         } as ProcessResult)
 
-      const updateListingStatusSpy = jest
-        .spyOn(leasingAdapter, 'updateListingStatus')
-        .mockResolvedValueOnce({ ok: true, data: null })
-
       const result = await replyProcesses.acceptOffer(123)
 
       expect(result).toMatchObject({
         processStatus: ProcessStatus.successful,
       })
 
-      expect(updateListingStatusSpy).toHaveBeenCalledTimes(1)
       denyOfferSpy.mockRestore()
     })
   })


### PR DESCRIPTION
Part of https://linear.app/mimer-onecore/issue/UTH-125/inga-bilplatser-syns-i-historik-fliken

We were already setting the listing status to assigned as part of `closeOfferByAccept`, then setting it again to closed.
