### PR TITLE
UTH-144: Extend application profile CRUD and add housing reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "koa2-swagger-ui": "^5.10.0",
         "lodash": "^4.17.21",
         "odoo-await": "^3.4.1",
-        "onecore-types": "^2.4.0",
+        "onecore-types": "^2.5.0",
         "onecore-utilities": "^1.1.0",
         "pino": "^9.1.0",
         "pino-elasticsearch": "^8.0.0",
@@ -7540,9 +7540,9 @@
       }
     },
     "node_modules/onecore-types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-2.4.0.tgz",
-      "integrity": "sha512-DfrAN+nKzFBKGrkVlNiLuRmhnEqBdMynX+1L48wzQSZndHCF3EmnZ/DpjyF5VV9MRcODzz6O+swMm5jW+92Gnw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-2.5.0.tgz",
+      "integrity": "sha512-DSv5wIn9DDtUanMOevoyDkDtlPUq5VbO57wASHdKMN32fCnfmVU/pEbzKX/ctsD+A5HQeMH0DiVQp8zhUH0mAQ==",
       "dependencies": {
         "release-please": "^16.8.0"
       },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "koa2-swagger-ui": "^5.10.0",
     "lodash": "^4.17.21",
     "odoo-await": "^3.4.1",
-    "onecore-types": "^2.4.0",
+    "onecore-types": "^2.5.0",
     "onecore-utilities": "^1.1.0",
     "pino": "^9.1.0",
     "pino-elasticsearch": "^8.0.0",

--- a/src/adapters/leasing-adapter/index.ts
+++ b/src/adapters/leasing-adapter/index.ts
@@ -523,7 +523,7 @@ type CreateOrUpdateApplicationProfileResponseData = z.infer<
   typeof leasing.CreateOrUpdateApplicationProfileResponseDataSchema
 >
 
-type CreateOrUpdateApplicationProfileRequestParams = z.infer<
+export type CreateOrUpdateApplicationProfileRequestParams = z.infer<
   typeof leasing.CreateOrUpdateApplicationProfileRequestParamsSchema
 >
 

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -1499,10 +1499,10 @@ export const routes = (router: KoaRouter) => {
 
     ctx.status = 200
     ctx.body = {
-      content:
-        schemas.client.applicationProfile.GetApplicationProfileResponseDataSchema.parse(
-          profile.data
-        ),
+      content: profile.data satisfies z.infer<
+        typeof schemas.client.applicationProfile.GetApplicationProfileResponseData
+      >,
+
       ...metadata,
     }
   })
@@ -1631,10 +1631,9 @@ export const routes = (router: KoaRouter) => {
 
       ctx.status = createOrUpdate.statusCode ?? 200
       ctx.body = {
-        content:
-          schemas.client.applicationProfile.UpdateApplicationProfileResponseData.parse(
-            createOrUpdate.data
-          ),
+        content: createOrUpdate.data satisfies z.infer<
+          typeof schemas.client.applicationProfile.UpdateApplicationProfileResponseData
+        >,
         ...metadata,
       }
     }

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -1592,7 +1592,6 @@ export const routes = (router: KoaRouter) => {
           ? {
               email: body.housingReference.email,
               expiresAt,
-              name: body.housingReference.name,
               phone: body.housingReference.phone,
               ...(getApplicationProfile.ok &&
               getApplicationProfile.data.housingReference

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -1574,6 +1574,7 @@ export const routes = (router: KoaRouter) => {
         await leasingAdapter.getApplicationProfileByContactCode(
           ctx.params.contactCode
         )
+
       if (
         !getApplicationProfile.ok &&
         getApplicationProfile.err !== 'not-found'

--- a/src/services/lease-service/schemas/client/application-profile/index.ts
+++ b/src/services/lease-service/schemas/client/application-profile/index.ts
@@ -34,8 +34,6 @@ export const UpdateApplicationProfileResponseData =
           name: true,
           phone: true,
           expiresAt: true,
-          applicationProfileId: true,
-          createdAt: true,
         })
         .optional(),
   })
@@ -60,8 +58,6 @@ export const GetApplicationProfileResponseDataSchema =
           name: true,
           phone: true,
           expiresAt: true,
-          applicationProfileId: true,
-          createdAt: true,
         })
         .optional(),
   })

--- a/src/services/lease-service/schemas/client/application-profile/index.ts
+++ b/src/services/lease-service/schemas/client/application-profile/index.ts
@@ -1,0 +1,67 @@
+import { leasing } from 'onecore-types'
+
+export const UpdateApplicationProfileRequestParams =
+  leasing.CreateOrUpdateApplicationProfileRequestParamsSchema.pick({
+    numChildren: true,
+    numAdults: true,
+    landlord: true,
+    housingType: true,
+    housingTypeDescription: true,
+  }).extend({
+    housingReference:
+      leasing.CreateOrUpdateApplicationProfileRequestParamsSchema.shape.housingReference
+        .unwrap()
+        .pick({ email: true, name: true, phone: true })
+        .optional(),
+  })
+
+export const UpdateApplicationProfileResponseData =
+  leasing.CreateOrUpdateApplicationProfileResponseDataSchema.pick({
+    id: true,
+    contactCode: true,
+    expiresAt: true,
+    housingTypeDescription: true,
+    housingType: true,
+    landlord: true,
+    numAdults: true,
+    numChildren: true,
+  }).extend({
+    housingReference:
+      leasing.CreateOrUpdateApplicationProfileResponseDataSchema.shape.housingReference
+        .unwrap()
+        .pick({
+          email: true,
+          name: true,
+          phone: true,
+          expiresAt: true,
+          applicationProfileId: true,
+          createdAt: true,
+        })
+        .optional(),
+  })
+
+export const GetApplicationProfileResponseDataSchema =
+  leasing.GetApplicationProfileResponseDataSchema.pick({
+    contactCode: true,
+    createdAt: true,
+    expiresAt: true,
+    housingType: true,
+    housingTypeDescription: true,
+    id: true,
+    landlord: true,
+    numAdults: true,
+    numChildren: true,
+  }).extend({
+    housingReference:
+      leasing.GetApplicationProfileResponseDataSchema.shape.housingReference
+        .unwrap()
+        .pick({
+          email: true,
+          name: true,
+          phone: true,
+          expiresAt: true,
+          applicationProfileId: true,
+          createdAt: true,
+        })
+        .optional(),
+  })

--- a/src/services/lease-service/schemas/client/application-profile/index.ts
+++ b/src/services/lease-service/schemas/client/application-profile/index.ts
@@ -38,7 +38,7 @@ export const UpdateApplicationProfileResponseData =
         .optional(),
   })
 
-export const GetApplicationProfileResponseDataSchema =
+export const GetApplicationProfileResponseData =
   leasing.GetApplicationProfileResponseDataSchema.pick({
     contactCode: true,
     createdAt: true,

--- a/src/services/lease-service/schemas/client/application-profile/index.ts
+++ b/src/services/lease-service/schemas/client/application-profile/index.ts
@@ -11,7 +11,7 @@ export const UpdateApplicationProfileRequestParams =
     housingReference:
       leasing.CreateOrUpdateApplicationProfileRequestParamsSchema.shape.housingReference
         .unwrap()
-        .pick({ email: true, name: true, phone: true })
+        .pick({ email: true, phone: true })
         .optional(),
   })
 
@@ -31,7 +31,6 @@ export const UpdateApplicationProfileResponseData =
         .unwrap()
         .pick({
           email: true,
-          name: true,
           phone: true,
           expiresAt: true,
         })
@@ -55,7 +54,6 @@ export const GetApplicationProfileResponseData =
         .unwrap()
         .pick({
           email: true,
-          name: true,
           phone: true,
           expiresAt: true,
         })

--- a/src/services/lease-service/schemas/client/index.ts
+++ b/src/services/lease-service/schemas/client/index.ts
@@ -1,0 +1,1 @@
+export * as applicationProfile from './application-profile'

--- a/src/services/lease-service/schemas/index.ts
+++ b/src/services/lease-service/schemas/index.ts
@@ -1,0 +1,5 @@
+import * as client from './client'
+
+export const schemas = {
+  client,
+}

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -19,6 +19,7 @@ import * as replyToOffer from '../../../processes/parkingspaces/internal/reply-t
 
 import * as factory from '../../../../test/factories'
 import { ProcessStatus } from '../../../common/types'
+import { schemas } from '../schemas'
 
 const app = new Koa()
 const router = new KoaRouter()
@@ -559,7 +560,9 @@ describe('lease-service', () => {
 
       expect(res.status).toBe(200)
       expect(() =>
-        leasing.GetApplicationProfileResponseDataSchema.parse(res.body.content)
+        schemas.client.applicationProfile.GetApplicationProfileResponseDataSchema.parse(
+          res.body.content
+        )
       ).not.toThrow()
     })
   })
@@ -593,11 +596,16 @@ describe('lease-service', () => {
 
       const res = await request(app.callback())
         .post('/contacts/1234/application-profile')
-        .send({ numAdults: 0, numChildren: 0 })
+        .send({
+          numAdults: 0,
+          numChildren: 0,
+          housingType: 'foo',
+          housingTypeDescription: 'bar',
+        })
 
       expect(res.status).toBe(200)
       expect(() =>
-        leasing.CreateOrUpdateApplicationProfileResponseDataSchema.parse(
+        schemas.client.applicationProfile.UpdateApplicationProfileResponseData.parse(
           res.body.content
         )
       ).not.toThrow()

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -9,7 +9,6 @@ import {
   GetActiveOfferByListingIdErrorCodes,
   ListingStatus,
   UpdateListingStatusErrorCodes,
-  leasing,
 } from 'onecore-types'
 
 import { routes } from '../index'
@@ -577,6 +576,20 @@ describe('lease-service', () => {
     })
 
     it('responds with 200 and application profile', async () => {
+      jest
+        .spyOn(tenantLeaseAdapter, 'getApplicationProfileByContactCode')
+        .mockResolvedValueOnce({
+          ok: true,
+          data: {
+            contactCode: '1234',
+            createdAt: new Date(),
+            expiresAt: null,
+            id: 1,
+            numAdults: 0,
+            numChildren: 0,
+          },
+        })
+
       jest
         .spyOn(
           tenantLeaseAdapter,

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -559,7 +559,7 @@ describe('lease-service', () => {
 
       expect(res.status).toBe(200)
       expect(() =>
-        schemas.client.applicationProfile.GetApplicationProfileResponseDataSchema.parse(
+        schemas.client.applicationProfile.GetApplicationProfileResponseData.parse(
           res.body.content
         )
       ).not.toThrow()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./build",
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "noErrorTruncation": true,
     "types": ["koa-body", "jest"],
     "strict": true
   }


### PR DESCRIPTION
Adds information to the application profile GET and POST endpoints.

We're in a bit of a limbo here where we will need separate request/response schemas for mimer.nu (client) and medportalen (internal-portal).

I've added zod schemas in schemas/client/application-profile
These correspond to what the GET and POST from mimer.nu (client) should look like.

Since we only have one endpoint in leasing at the moment, the POST application-profile actually fetches the current profile from leasing and include fields in the update that the original client doesn't know about:
- reviewStatus
- reviewStatusReason
- reviewedAt