### PR TITLE
fix: use v1 schemas for application profile

### DIFF
--- a/src/adapters/leasing-adapter/index.ts
+++ b/src/adapters/leasing-adapter/index.ts
@@ -491,7 +491,7 @@ const validatePropertyRentalRules = async (
 }
 
 type GetApplicationProfileResponseData = z.infer<
-  typeof leasing.GetApplicationProfileResponseDataSchema
+  typeof leasing.v1.GetApplicationProfileResponseDataSchema
 >
 
 async function getApplicationProfileByContactCode(
@@ -520,11 +520,11 @@ async function getApplicationProfileByContactCode(
 }
 
 type CreateOrUpdateApplicationProfileResponseData = z.infer<
-  typeof leasing.CreateOrUpdateApplicationProfileResponseDataSchema
+  typeof leasing.v1.CreateOrUpdateApplicationProfileResponseDataSchema
 >
 
 export type CreateOrUpdateApplicationProfileRequestParams = z.infer<
-  typeof leasing.CreateOrUpdateApplicationProfileRequestParamsSchema
+  typeof leasing.v1.CreateOrUpdateApplicationProfileRequestParamsSchema
 >
 
 async function createOrUpdateApplicationProfileByContactCode(

--- a/src/services/lease-service/schemas/client/application-profile/index.ts
+++ b/src/services/lease-service/schemas/client/application-profile/index.ts
@@ -1,7 +1,7 @@
 import { leasing } from 'onecore-types'
 
 export const UpdateApplicationProfileRequestParams =
-  leasing.CreateOrUpdateApplicationProfileRequestParamsSchema.pick({
+  leasing.v1.CreateOrUpdateApplicationProfileRequestParamsSchema.pick({
     numChildren: true,
     numAdults: true,
     landlord: true,
@@ -9,7 +9,7 @@ export const UpdateApplicationProfileRequestParams =
     housingTypeDescription: true,
   }).extend({
     housingReference:
-      leasing.CreateOrUpdateApplicationProfileRequestParamsSchema.shape.housingReference.pick(
+      leasing.v1.CreateOrUpdateApplicationProfileRequestParamsSchema.shape.housingReference.pick(
         {
           email: true,
           phone: true,
@@ -24,7 +24,7 @@ export const UpdateApplicationProfileRequestParams =
   })
 
 export const UpdateApplicationProfileResponseData =
-  leasing.CreateOrUpdateApplicationProfileResponseDataSchema
+  leasing.v1.CreateOrUpdateApplicationProfileResponseDataSchema
 
 export const GetApplicationProfileResponseData =
-  leasing.GetApplicationProfileResponseDataSchema
+  leasing.v1.GetApplicationProfileResponseDataSchema

--- a/test/factories/application-profile.ts
+++ b/test/factories/application-profile.ts
@@ -1,8 +1,11 @@
 import { Factory } from 'fishery'
-import {
-  ApplicationProfile,
-  ApplicationProfileHousingReference,
-} from 'onecore-types'
+import { schemas } from 'onecore-types'
+import { z } from 'zod'
+
+type ApplicationProfile = z.infer<typeof schemas.v1.ApplicationProfileSchema>
+type ApplicationProfileHousingReference = z.infer<
+  typeof schemas.v1.ApplicationProfileHousingReferenceSchema
+>
 
 export const ApplicationProfileFactory = Factory.define<ApplicationProfile>(
   ({ sequence }) => ({


### PR DESCRIPTION
Use v1 exports from onecore-types 