### PR TITLE
refactor: use booleans for deciding what to include on leases

### DIFF
--- a/src/adapters/leasing-adapter/index.ts
+++ b/src/adapters/leasing-adapter/index.ts
@@ -45,15 +45,18 @@ const getLease = async (
 
 const getLeasesForPnr = async (
   nationalRegistrationNumber: string,
-  includeTerminatedLeases: string | string[] | undefined,
-  includeContacts: string | string[] | undefined
+  includeTerminatedLeases: boolean,
+  includeContacts: boolean
 ): Promise<Lease[]> => {
-  const leasesResponse = await axios(
-    tenantsLeasesServiceUrl +
-      '/leases/for/nationalRegistrationNumber/' +
-      nationalRegistrationNumber +
-      (includeContacts ? '?includeContacts=true' : '')
+  const queryParams = new URLSearchParams({
+    includeTerminatedLeases: includeTerminatedLeases.toString(),
+    includeContacts: includeContacts.toString(),
+  })
+
+  const leasesResponse = await axios.get(
+    `${tenantsLeasesServiceUrl}/leases/for/nationalRegistrationNumber/${nationalRegistrationNumber}?${queryParams.toString()}`
   )
+
   return leasesResponse.data.content
 }
 

--- a/src/processes/parkingspaces/internal/create-note-of-interest.ts
+++ b/src/processes/parkingspaces/internal/create-note-of-interest.ts
@@ -90,8 +90,8 @@ export const createNoteOfInterestForInternalParkingSpace = async (
     //step 3a. Check if applicant is tenant
     const leases = await getLeasesForPnr(
       applicantContact.nationalRegistrationNumber,
-      undefined,
-      undefined
+      true,
+      false
     )
     if (leases.length < 1) {
       return endFailingProcess(

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -30,8 +30,8 @@ const getLeasesWithRelatedEntitiesForPnr = async (
 ) => {
   const leases = await leasingAdapter.getLeasesForPnr(
     nationalRegistrationNumber,
-    undefined,
-    'true'
+    false,
+    true
   )
 
   return leases

--- a/src/services/property-management-service/index.ts
+++ b/src/services/property-management-service/index.ts
@@ -695,8 +695,8 @@ export const routes = (router: KoaRouter) => {
 
       const leases = await leasingAdapter.getLeasesForPnr(
         contactResult.data.nationalRegistrationNumber,
-        'false',
-        'false'
+        false,
+        false
       )
       const promises = leases
         .filter(

--- a/src/services/property-management-service/tests/index.test.ts
+++ b/src/services/property-management-service/tests/index.test.ts
@@ -150,8 +150,8 @@ describe('rental-property-service index', () => {
       expect(getContactSpy).toHaveBeenCalledWith('P965339')
       expect(getLeasesForPnrSpy).toHaveBeenCalledWith(
         '199404084924',
-        'false',
-        'false'
+        false,
+        false
       )
       expect(getMaintenanceUnitsForRentalPropertySpy).toHaveBeenCalledWith(
         '705-022-04-0201'

--- a/src/services/work-order-service/index.ts
+++ b/src/services/work-order-service/index.ts
@@ -139,8 +139,8 @@ export const routes = (router: KoaRouter) => {
       pnr: async () => {
         const leases = await leasingAdapter.getLeasesForPnr(
           ctx.params.identifier,
-          undefined,
-          'true'
+          false,
+          true
         )
         if (leases) {
           await getRentalPropertyInfoWithLeases(leases)
@@ -153,8 +153,8 @@ export const routes = (router: KoaRouter) => {
         if (contact) {
           const leases = await leasingAdapter.getLeasesForPnr(
             contact.nationalRegistrationNumber,
-            undefined,
-            'true'
+            false,
+            true
           )
           if (leases) {
             await getRentalPropertyInfoWithLeases(leases)
@@ -168,8 +168,8 @@ export const routes = (router: KoaRouter) => {
         if (contactResult.ok) {
           const leases = await leasingAdapter.getLeasesForPnr(
             contactResult.data.nationalRegistrationNumber,
-            undefined,
-            'true'
+            false,
+            true
           )
           if (leases) {
             await getRentalPropertyInfoWithLeases(leases)

--- a/src/services/work-order-service/tests/index.test.ts
+++ b/src/services/work-order-service/tests/index.test.ts
@@ -104,7 +104,7 @@ describe('work-order-service index', () => {
       )
 
       expect(res.status).toBe(200)
-      expect(getLeasesForPnrSpy).toHaveBeenCalledWith('123', undefined, 'true')
+      expect(getLeasesForPnrSpy).toHaveBeenCalledWith('123', false, true)
       expect(getRentalPropertyInfoSpy).toHaveBeenCalledWith('123-456-789')
       expect(res.body.content).toBeDefined()
     })


### PR DESCRIPTION
Also, make sure we include "terminated" leases in create-note-of-interest when getting leases. This is to make sure we get leases that are not yet active