### PR TITLE
UTH-198 - unbreak application profile

### DIFF
--- a/src/services/lease-service/application-profile-old.ts
+++ b/src/services/lease-service/application-profile-old.ts
@@ -1,0 +1,96 @@
+import KoaRouter from '@koa/router'
+import dayjs from 'dayjs'
+import { generateRouteMetadata } from 'onecore-utilities'
+import { z } from 'zod'
+
+import * as leasingAdapter from '../../adapters/leasing-adapter'
+import { parseRequestBody } from '../../middlewares/parse-request-body'
+import { schemas } from './schemas'
+
+// TODO: Remove this once all routes are migrated to the new application
+// profile (with housing references)
+export const routes = (router: KoaRouter) => {
+  router.post(
+    '(.*)/contacts/:contactCode/application-profile',
+    parseRequestBody(
+      schemas.client.applicationProfile.UpdateApplicationProfileRequestParamsOld
+    ),
+    async (ctx) => {
+      const metadata = generateRouteMetadata(ctx)
+      // TODO: Something wrong with parseRequestBody types.
+      // Body should be inferred from middleware
+      const body = ctx.request.body as z.infer<
+        typeof schemas.client.applicationProfile.UpdateApplicationProfileRequestParamsOld
+      >
+
+      const getApplicationProfile =
+        await leasingAdapter.getApplicationProfileByContactCode(
+          ctx.params.contactCode
+        )
+
+      if (
+        !getApplicationProfile.ok &&
+        getApplicationProfile.err !== 'not-found'
+      ) {
+        ctx.status = 500
+        ctx.body = { error: 'unknown', ...metadata }
+        return
+      }
+
+      const expiresAt = dayjs(new Date()).add(6, 'months').toDate()
+      const housingReferenceParams: leasingAdapter.CreateOrUpdateApplicationProfileRequestParams['housingReference'] =
+        {
+          email: body.housingReference?.email ?? null,
+          expiresAt,
+          phone: body.housingReference?.phone ?? null,
+          ...(getApplicationProfile.ok &&
+          getApplicationProfile.data.housingReference
+            ? {
+                reviewStatus:
+                  getApplicationProfile.data.housingReference.reviewStatus,
+                reviewedAt:
+                  getApplicationProfile.data.housingReference.reviewedAt,
+              }
+            : {
+                reviewStatus: 'pending',
+                reviewStatusReason: null,
+                reviewedAt: null,
+              }),
+          comment: null,
+          reasonRejected: null,
+          reviewStatus: 'PENDING',
+          reviewedAt: null,
+          reviewedBy: null,
+        }
+
+      const createOrUpdate =
+        await leasingAdapter.createOrUpdateApplicationProfileByContactCode(
+          ctx.params.contactCode,
+          {
+            housingTypeDescription: body.housingTypeDescription ?? null,
+            expiresAt,
+            housingReference: housingReferenceParams,
+            lastUpdatedAt: new Date(),
+            housingType: 'OTHER',
+            landlord: body.landlord ?? null,
+            numAdults: body.numAdults,
+            numChildren: body.numChildren,
+          }
+        )
+
+      if (!createOrUpdate.ok) {
+        ctx.status = 500
+        ctx.body = { error: 'unknown', ...metadata }
+        return
+      }
+
+      ctx.status = createOrUpdate.statusCode ?? 200
+      ctx.body = {
+        content: createOrUpdate.data satisfies z.infer<
+          typeof schemas.client.applicationProfile.UpdateApplicationProfileResponseData
+        >,
+        ...metadata,
+      }
+    }
+  )
+}

--- a/src/services/lease-service/application-profile-old.ts
+++ b/src/services/lease-service/application-profile-old.ts
@@ -40,22 +40,9 @@ export const routes = (router: KoaRouter) => {
       const expiresAt = dayjs(new Date()).add(6, 'months').toDate()
       const housingReferenceParams: leasingAdapter.CreateOrUpdateApplicationProfileRequestParams['housingReference'] =
         {
-          email: body.housingReference?.email ?? null,
           expiresAt,
+          email: body.housingReference?.email ?? null,
           phone: body.housingReference?.phone ?? null,
-          ...(getApplicationProfile.ok &&
-          getApplicationProfile.data.housingReference
-            ? {
-                reviewStatus:
-                  getApplicationProfile.data.housingReference.reviewStatus,
-                reviewedAt:
-                  getApplicationProfile.data.housingReference.reviewedAt,
-              }
-            : {
-                reviewStatus: 'pending',
-                reviewStatusReason: null,
-                reviewedAt: null,
-              }),
           comment: null,
           reasonRejected: null,
           reviewStatus: 'PENDING',

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -1754,14 +1754,14 @@ export const routes = (router: KoaRouter) => {
   router.post(
     '(.*)/contacts/:contactCode/application-profile',
     parseRequestBody(
-      schemas.client.applicationProfile.UpdateApplicationProfileRequestParams
+      schemas.client.applicationProfile.UpdateApplicationProfileRequestParamsOld
     ),
     async (ctx) => {
       const metadata = generateRouteMetadata(ctx)
       // TODO: Something wrong with parseRequestBody types.
       // Body should be inferred from middleware
       const body = ctx.request.body as z.infer<
-        typeof schemas.client.applicationProfile.UpdateApplicationProfileRequestParams
+        typeof schemas.client.applicationProfile.UpdateApplicationProfileRequestParamsOld
       >
 
       const getApplicationProfile =
@@ -1781,9 +1781,9 @@ export const routes = (router: KoaRouter) => {
       const expiresAt = dayjs(new Date()).add(6, 'months').toDate()
       const housingReferenceParams: leasingAdapter.CreateOrUpdateApplicationProfileRequestParams['housingReference'] =
         {
-          email: body.housingReference.email,
+          email: body.housingReference?.email ?? null,
           expiresAt,
-          phone: body.housingReference.phone,
+          phone: body.housingReference?.phone ?? null,
           ...(getApplicationProfile.ok &&
           getApplicationProfile.data.housingReference
             ? {
@@ -1799,7 +1799,7 @@ export const routes = (router: KoaRouter) => {
               }),
           comment: null,
           reasonRejected: null,
-          reviewStatus: 'REFERENCE_NOT_REQUIRED',
+          reviewStatus: 'PENDING',
           reviewedAt: null,
           reviewedBy: null,
         }
@@ -1808,10 +1808,14 @@ export const routes = (router: KoaRouter) => {
         await leasingAdapter.createOrUpdateApplicationProfileByContactCode(
           ctx.params.contactCode,
           {
-            ...body,
+            housingTypeDescription: body.housingTypeDescription ?? null,
             expiresAt,
             housingReference: housingReferenceParams,
             lastUpdatedAt: new Date(),
+            housingType: 'OTHER',
+            landlord: body.landlord ?? null,
+            numAdults: body.numAdults,
+            numChildren: body.numChildren,
           }
         )
 

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -20,6 +20,8 @@ import { makeAdminApplicationProfileRequestParams } from './helpers/application-
 import { schemas } from './schemas'
 import { isAllowedNumResidents } from './services/is-allowed-num-residents'
 
+import { routes as applicationProfileRoutesOld } from './application-profile-old'
+
 const getLeaseWithRelatedEntities = async (rentalId: string) => {
   const lease = await leasingAdapter.getLease(rentalId, 'true')
 
@@ -54,6 +56,10 @@ const getLeasesWithRelatedEntitiesForPnr = async (
  *   - bearerAuth: []
  */
 export const routes = (router: KoaRouter) => {
+  // TODO: Remove this once all routes are migrated to the new application
+  // profile (with housing references)
+  applicationProfileRoutesOld(router)
+
   /**
    * @swagger
    * /leases/for/{pnr}:
@@ -1747,90 +1753,6 @@ export const routes = (router: KoaRouter) => {
             ),
           ...metadata,
         }
-      }
-    }
-  )
-
-  router.post(
-    '(.*)/contacts/:contactCode/application-profile',
-    parseRequestBody(
-      schemas.client.applicationProfile.UpdateApplicationProfileRequestParamsOld
-    ),
-    async (ctx) => {
-      const metadata = generateRouteMetadata(ctx)
-      // TODO: Something wrong with parseRequestBody types.
-      // Body should be inferred from middleware
-      const body = ctx.request.body as z.infer<
-        typeof schemas.client.applicationProfile.UpdateApplicationProfileRequestParamsOld
-      >
-
-      const getApplicationProfile =
-        await leasingAdapter.getApplicationProfileByContactCode(
-          ctx.params.contactCode
-        )
-
-      if (
-        !getApplicationProfile.ok &&
-        getApplicationProfile.err !== 'not-found'
-      ) {
-        ctx.status = 500
-        ctx.body = { error: 'unknown', ...metadata }
-        return
-      }
-
-      const expiresAt = dayjs(new Date()).add(6, 'months').toDate()
-      const housingReferenceParams: leasingAdapter.CreateOrUpdateApplicationProfileRequestParams['housingReference'] =
-        {
-          email: body.housingReference?.email ?? null,
-          expiresAt,
-          phone: body.housingReference?.phone ?? null,
-          ...(getApplicationProfile.ok &&
-          getApplicationProfile.data.housingReference
-            ? {
-                reviewStatus:
-                  getApplicationProfile.data.housingReference.reviewStatus,
-                reviewedAt:
-                  getApplicationProfile.data.housingReference.reviewedAt,
-              }
-            : {
-                reviewStatus: 'pending',
-                reviewStatusReason: null,
-                reviewedAt: null,
-              }),
-          comment: null,
-          reasonRejected: null,
-          reviewStatus: 'PENDING',
-          reviewedAt: null,
-          reviewedBy: null,
-        }
-
-      const createOrUpdate =
-        await leasingAdapter.createOrUpdateApplicationProfileByContactCode(
-          ctx.params.contactCode,
-          {
-            housingTypeDescription: body.housingTypeDescription ?? null,
-            expiresAt,
-            housingReference: housingReferenceParams,
-            lastUpdatedAt: new Date(),
-            housingType: 'OTHER',
-            landlord: body.landlord ?? null,
-            numAdults: body.numAdults,
-            numChildren: body.numChildren,
-          }
-        )
-
-      if (!createOrUpdate.ok) {
-        ctx.status = 500
-        ctx.body = { error: 'unknown', ...metadata }
-        return
-      }
-
-      ctx.status = createOrUpdate.statusCode ?? 200
-      ctx.body = {
-        content: createOrUpdate.data satisfies z.infer<
-          typeof schemas.client.applicationProfile.UpdateApplicationProfileResponseData
-        >,
-        ...metadata,
       }
     }
   )

--- a/src/services/lease-service/schemas/client/application-profile/index.ts
+++ b/src/services/lease-service/schemas/client/application-profile/index.ts
@@ -14,6 +14,21 @@ export const UpdateApplicationProfileRequestParams =
       ),
   })
 
+export const UpdateApplicationProfileRequestParamsOld =
+  leasing.CreateOrUpdateApplicationProfileRequestParamsSchema.pick({
+    numChildren: true,
+    numAdults: true,
+    landlord: true,
+    housingType: true,
+    housingTypeDescription: true,
+  }).extend({
+    housingReference:
+      leasing.CreateOrUpdateApplicationProfileRequestParamsSchema.shape.housingReference
+        .unwrap()
+        .pick({ email: true, phone: true })
+        .optional(),
+  })
+
 export const UpdateApplicationProfileResponseData =
   leasing.v1.CreateOrUpdateApplicationProfileResponseDataSchema.pick({
     contactCode: true,

--- a/src/services/lease-service/schemas/client/application-profile/index.ts
+++ b/src/services/lease-service/schemas/client/application-profile/index.ts
@@ -14,6 +14,8 @@ export const UpdateApplicationProfileRequestParams =
       ),
   })
 
+// TODO: Remove this once all routes are migrated to the new application
+// profile (with housing references)
 export const UpdateApplicationProfileRequestParamsOld =
   leasing.CreateOrUpdateApplicationProfileRequestParamsSchema.pick({
     numChildren: true,


### PR DESCRIPTION
Adds back the "old" application profile route and schema for backwards compatibility towards current main and production environment.

An earlier migration on the `develop-uthyrning-bostader` creates a now required housing reference row for each existing application profile, which defaults review status to "PENDING". Same approach is used here for each "old" application profile POST that we now receive. 

Part of this backwards compatibility fix is to default the housingType to "OTHER". Its non-nullable on leasing so we have to put in something from core. It's actually nullable in the database though so we could make it nullable in the schema too. But if it doesnt hurt to put in "OTHER" we can avoid that change in onecore-types.

I think these changes should make `develop-uthyrning-bostader` fully compatible with `main` but we have to test of course. I think the only consumer of GET and POST application profile on main is mimer.nu.