### PR TITLE
Feat: UTH-216 Show Error Message when no Valid Housing Contract can be Found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "koa2-swagger-ui": "^5.10.0",
         "lodash": "^4.17.21",
         "odoo-await": "^3.4.1",
-        "onecore-types": "^3.4.0",
+        "onecore-types": "^3.5.1",
         "onecore-utilities": "^1.1.0",
         "pino": "^9.1.0",
         "pino-elasticsearch": "^8.0.0",
@@ -7540,9 +7540,9 @@
       }
     },
     "node_modules/onecore-types": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-3.4.0.tgz",
-      "integrity": "sha512-RP+7+1MnVUw4b3ZvjF7fyMwGlIzwHgbHM3nUSsCWCKQmye6KyUdr2mH70zXtMzJXffbbJfFEtUYGmmAUTcf8kA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-3.5.1.tgz",
+      "integrity": "sha512-XLmtOf3LqWiprX5dVnu2CWf9DcucfirUDSu6X6TEFNYHS1kxpGZEag6/pdICFoFJihg1FYqOSmmkN5ehKwAsfQ==",
       "license": "ISC",
       "dependencies": {
         "release-please": "^16.8.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "koa2-swagger-ui": "^5.10.0",
     "lodash": "^4.17.21",
     "odoo-await": "^3.4.1",
-    "onecore-types": "^3.4.0",
+    "onecore-types": "^3.5.1",
     "onecore-utilities": "^1.1.0",
     "pino": "^9.1.0",
     "pino-elasticsearch": "^8.0.0",

--- a/src/adapters/leasing-adapter/index.ts
+++ b/src/adapters/leasing-adapter/index.ts
@@ -144,7 +144,12 @@ const getContactByContactCode = async (
 
 const getTenantByContactCode = async (
   contactCode: string
-): Promise<AdapterResult<Tenant, 'unknown' | 'no-valid-housing-contract'>> => {
+): Promise<
+  AdapterResult<
+    Tenant,
+    'unknown' | 'no-valid-housing-contract' | 'contact-not-found'
+  >
+> => {
   try {
     const res = await axios.get(
       `${tenantsLeasesServiceUrl}/tenants/contactCode/${contactCode}`
@@ -158,7 +163,7 @@ const getTenantByContactCode = async (
   } catch (err) {
     logger.error({ err }, 'leasing-adapter.getTenantByContactCode')
 
-    if (err instanceof AxiosError && err.response?.data?.type)
+    if (err instanceof AxiosError)
       return { ok: false, err: err.response?.data?.type }
     return { ok: false, err: 'unknown' }
   }

--- a/src/adapters/leasing-adapter/index.ts
+++ b/src/adapters/leasing-adapter/index.ts
@@ -144,17 +144,22 @@ const getContactByContactCode = async (
 
 const getTenantByContactCode = async (
   contactCode: string
-): Promise<AdapterResult<Tenant, 'unknown'>> => {
+): Promise<AdapterResult<Tenant, 'unknown' | 'no-valid-housing-contract'>> => {
   try {
     const res = await axios.get(
       `${tenantsLeasesServiceUrl}/tenants/contactCode/${contactCode}`
     )
 
-    if (!res.data.content) return { ok: false, err: 'unknown' }
+    if (!res.data.content) {
+      return { ok: false, err: 'unknown' }
+    }
 
     return { ok: true, data: res.data.content }
   } catch (err) {
     logger.error({ err }, 'leasing-adapter.getTenantByContactCode')
+
+    if (err instanceof AxiosError && err.response?.data?.type)
+      return { ok: false, err: err.response?.data?.type }
     return { ok: false, err: 'unknown' }
   }
 }

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -462,8 +462,28 @@ export const routes = (router: KoaRouter) => {
     )
 
     if (!res.ok) {
+      if (res.err === 'no-valid-housing-contract') {
+        ctx.status = 500
+        ctx.body = {
+          // reason: 'no-valid-housing-contract',
+          // error: 'No valid housing contract found',
+          type: 'no-valid-housing-contract',
+          title: 'No valid housing contract found',
+          status: 500,
+          detail:
+            'A housing contract needs to be current or upcoming to be a valid contract when applying for a parking space.',
+          ...metadata,
+        }
+        return
+      }
+
       ctx.status = 500
-      ctx.body = { error: 'Internal server error', ...metadata }
+      ctx.body = {
+        type: res.err,
+        title: 'Internal server error',
+        status: 500,
+        ...metadata,
+      }
       return
     }
 

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -7,7 +7,10 @@
  */
 import KoaRouter from '@koa/router'
 import dayjs from 'dayjs'
-import { GetActiveOfferByListingIdErrorCodes } from 'onecore-types'
+import {
+  GetActiveOfferByListingIdErrorCodes,
+  RouteErrorResponse,
+} from 'onecore-types'
 import { logger, generateRouteMetadata } from 'onecore-utilities'
 import { z } from 'zod'
 
@@ -455,6 +458,39 @@ export const routes = (router: KoaRouter) => {
     }
   })
 
+  /**
+   * @swagger
+   * /tenants/contactCode/{contactCode}:
+   *   get:
+   *     summary: Get tenant by contact code
+   *     tags:
+   *       - Lease service
+   *     description: Retrieves a tenant based on the provided contact code.
+   *     parameters:
+   *       - in: path
+   *         name: contactCode
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The contact code used to identify the contact.
+   *     responses:
+   *       200:
+   *         description: Successfully retrieved tenant information.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: object
+   *                   description: The tenant data.
+   *       404:
+   *         description: Not found.
+   *       500:
+   *         description: Internal server error. Failed to retrieve Tenant information.
+   *     security:
+   *       - bearerAuth: []
+   */
   router.get('(.*)/tenants/contactCode/:contactCode', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
     const res = await leasingAdapter.getTenantByContactCode(
@@ -462,18 +498,28 @@ export const routes = (router: KoaRouter) => {
     )
 
     if (!res.ok) {
+      if (res.err === 'contact-not-found') {
+        ctx.status = 404
+        ctx.body = {
+          type: res.err,
+          title: 'Contact not found',
+          status: 404,
+          ...metadata,
+        } satisfies RouteErrorResponse
+        return
+      }
+
       if (res.err === 'no-valid-housing-contract') {
         ctx.status = 500
         ctx.body = {
-          // reason: 'no-valid-housing-contract',
-          // error: 'No valid housing contract found',
-          type: 'no-valid-housing-contract',
+          type: res.err,
           title: 'No valid housing contract found',
           status: 500,
           detail:
             'A housing contract needs to be current or upcoming to be a valid contract when applying for a parking space.',
           ...metadata,
-        }
+        } satisfies RouteErrorResponse
+
         return
       }
 
@@ -483,7 +529,7 @@ export const routes = (router: KoaRouter) => {
         title: 'Internal server error',
         status: 500,
         ...metadata,
-      }
+      } satisfies RouteErrorResponse
       return
     }
 


### PR DESCRIPTION
* Adapter can now return no-valid-housing-contract
* Route now returns error corresponding to the RFC 7807 standard