### PR TITLE
MIM-504: fetch leases by property id from leasing

### DIFF
--- a/src/adapters/leasing-adapter/index.ts
+++ b/src/adapters/leasing-adapter/index.ts
@@ -1,7 +1,6 @@
 import { loggedAxios as axios, logger } from 'onecore-utilities'
 import { AxiosError } from 'axios'
 import dayjs from 'dayjs'
-import querystring from 'querystring'
 import {
   ConsumerReport,
   Contact,

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -65,10 +65,6 @@ const getLeasesWithRelatedEntitiesForPnr = async (
  */
 export const routes = (router: KoaRouter) => {
   registerSchema('Lease', Lease)
-  registerSchema(
-    'GetLeaseForPropertyIdQueryParams',
-    GetLeaseForPropertyIdQueryParams
-  )
 
   // TODO: Remove this once all routes are migrated to the new application
   // profile (with housing references)
@@ -131,15 +127,21 @@ export const routes = (router: KoaRouter) => {
    *       - in: query
    *         name: includeUpcomingLeases
    *         schema:
-   *           $ref: '#/components/schemas/GetLeaseForPropertyIdQueryParams/properties/includeUpcomingLeases'
+   *           type: boolean
+   *           default: false
+   *         description: Whether to include upcoming leases in the response
    *       - in: query
    *         name: includeTerminatedLeases
    *         schema:
-   *           $ref: '#/components/schemas/GetLeaseForPropertyIdQueryParams/properties/includeTerminatedLeases'
+   *           type: boolean
+   *           default: false
+   *         description: Whether to include terminated leases in the response
    *       - in: query
    *         name: includeContacts
    *         schema:
-   *           $ref: '#/components/schemas/GetLeaseForPropertyIdQueryParams/properties/includeContacts'
+   *           type: boolean
+   *           default: false
+   *         description: Whether to include contact information in the response
    *     responses:
    *       '200':
    *         description: Successful response with leases and related entities

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -25,7 +25,11 @@ import { isAllowedNumResidents } from './services/is-allowed-num-residents'
 
 import { routes as applicationProfileRoutesOld } from './application-profile-old'
 import { registerSchema } from '../../utils/openapi'
-import { GetLeaseForPropertyIdQueryParams, Lease } from './schemas/lease'
+import {
+  GetLeaseForPropertyIdQueryParams,
+  Lease,
+  mapLease,
+} from './schemas/lease'
 
 const getLeaseWithRelatedEntities = async (rentalId: string) => {
   const lease = await leasingAdapter.getLease(rentalId, 'true')
@@ -144,10 +148,9 @@ export const routes = (router: KoaRouter) => {
         queryParams.data
       )
 
-      console.log(leases)
       ctx.status = 200
       ctx.body = {
-        content: leases,
+        content: leases.map(mapLease),
         ...metadata,
       }
     } catch (err) {

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -72,46 +72,7 @@ export const routes = (router: KoaRouter) => {
 
   /**
    * @swagger
-   * /leases/for/{pnr}:
-   *   get:
-   *     summary: Get leases with related entities for a specific Personal Number (PNR)
-   *     tags:
-   *       - Lease service
-   *     description: Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified Personal Number (PNR).
-   *     parameters:
-   *       - in: path
-   *         name: pnr
-   *         required: true
-   *         schema:
-   *           type: string
-   *         description: Personal Number (PNR) of the individual to fetch leases for.
-   *     responses:
-   *       '200':
-   *         description: Successful response with leases and related entities
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: array
-   *               items:
-   *                 type: object
-   *     security:
-   *       - bearerAuth: []
-   */
-  router.get('(.*)/leases/for/:pnr', async (ctx) => {
-    const metadata = generateRouteMetadata(ctx)
-    const responseData = await getLeasesWithRelatedEntitiesForPnr(
-      ctx.params.pnr
-    )
-
-    ctx.body = {
-      content: responseData,
-      ...metadata,
-    }
-  })
-
-  /**
-   * @swagger
-   * /leases/for/{propertyId}:
+   * /leases/for/propertyId/{propertyId}:
    *   get:
    *     summary: Get leases with related entities for a specific property id
    *     tags:
@@ -183,6 +144,7 @@ export const routes = (router: KoaRouter) => {
         queryParams.data
       )
 
+      console.log(leases)
       ctx.status = 200
       ctx.body = {
         content: leases,
@@ -191,6 +153,45 @@ export const routes = (router: KoaRouter) => {
     } catch (err) {
       logger.error({ err, metadata }, 'Error fetching leases from leasing')
       ctx.status = 500
+    }
+  })
+
+  /**
+   * @swagger
+   * /leases/for/{pnr}:
+   *   get:
+   *     summary: Get leases with related entities for a specific Personal Number (PNR)
+   *     tags:
+   *       - Lease service
+   *     description: Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified Personal Number (PNR).
+   *     parameters:
+   *       - in: path
+   *         name: pnr
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Personal Number (PNR) of the individual to fetch leases for.
+   *     responses:
+   *       '200':
+   *         description: Successful response with leases and related entities
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 type: object
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.get('(.*)/leases/for/:pnr', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+    const responseData = await getLeasesWithRelatedEntitiesForPnr(
+      ctx.params.pnr
+    )
+
+    ctx.body = {
+      content: responseData,
+      ...metadata,
     }
   })
 

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -146,9 +146,12 @@ export const routes = (router: KoaRouter) => {
    *         content:
    *           application/json:
    *             schema:
-   *               type: array
-   *               items:
-   *                 $ref: '#/components/schemas/Lease'
+   *               type: object
+   *               properties:
+   *                 content:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/Lease'
    *       '400':
    *         description: Invalid query parameters
    *         content:

--- a/src/services/lease-service/schemas/lease.ts
+++ b/src/services/lease-service/schemas/lease.ts
@@ -1,163 +1,73 @@
 import { z } from 'zod'
 
-export const LeaseStatus = z.enum([
-  'Current',
-  'Upcoming',
-  'AboutToEnd',
-  'Ended',
-])
+/**
+ * This is a partial zod representation of the current Lease type from onecore-types
+ * I believe the original type has issues with circular references and decided to leave those out
+ * as I believe the original Lease type will need some refactoring.
+ *
+ * Lease.tenants has a list of contacts, which in turn has a list of leases
+ * Lease.roomtype has a list of material choices, which also has circular references.
+ */
 
-export const PhoneNumber = z.object({
-  phoneNumber: z.string(),
-  type: z.string(),
-  isMainNumber: z.boolean(),
-})
-
-export const Address = z.object({
-  street: z.string(),
-  number: z.string(),
-  postalCode: z.string(),
-  city: z.string(),
-})
-
-export const ResidentialArea = z.object({
-  code: z.string(),
-  caption: z.string(),
-})
-
-export const MaterialOption = z.object({
-  materialOptionId: z.string(),
-  caption: z.string(),
-  shortDescription: z.string().optional(),
-  description: z.string().optional(),
-  coverImage: z.string().optional(),
-  images: z.array(z.string()).optional(),
-  roomTypeName: z.string().optional(),
-  materialOptionGroupName: z.string().optional(),
-})
-
-type MaterialOption = z.infer<typeof MaterialOption>
-
-const BaseMaterialOptionGroup = z.object({
-  materialOptionGroupId: z.string(),
-  roomTypeId: z.string(),
-  roomTypeName: z.string().optional(),
-  name: z.string().optional(),
-  actionName: z.string().optional(),
-  type: z.string(),
-})
-
-export type MaterialOptionGroup = z.infer<typeof BaseMaterialOptionGroup> & {
-  materialOptions?: MaterialOption[]
-  materialChoices?: MaterialChoice[]
-}
-
-export const MaterialOptionGroupSchema: z.ZodType<MaterialOptionGroup> =
-  BaseMaterialOptionGroup.extend({
-    materialOptions: z.array(MaterialOption).optional(),
-    materialChoices: z.lazy(() => z.array(MaterialChoiceSchema).optional()),
-  })
-
-const BaseMaterialChoice = z.object({
-  materialChoiceId: z.string(),
-  materialOptionId: z.string(),
-  materialOptionGroupId: z.string(),
-  apartmentId: z.string(),
-  roomTypeId: z.string(),
-  materialOption: MaterialOption.optional(),
-  roomType: z.lazy(() => RoomType).optional(),
-  status: z.string(),
-  dateOfSubmission: z.coerce.date().optional(),
-  dateOfCancellation: z.coerce.date().optional(),
-})
-
-type MaterialChoice = z.infer<typeof BaseMaterialChoice> & {
-  materialOptionGroup?: MaterialOptionGroup
-}
-
-export const MaterialChoiceSchema: z.ZodType<MaterialChoice> =
-  BaseMaterialChoice.extend({
-    materialOptionGroup: MaterialOptionGroupSchema.optional(),
-  })
-
-export const RoomType = z.object({
-  roomTypeId: z.string(),
-  name: z.string(),
-  materialOptionGroups: z.array(MaterialOptionGroupSchema).optional(),
-})
-
-export const RentalProperty = z.object({
-  rentalPropertyId: z.string(),
-  apartmentNumber: z.number(),
-  size: z.number(),
-  type: z.string(),
-  address: Address.optional(),
-  rentalPropertyType: z.string(),
-  additionsIncludedInRent: z.string(),
-  otherInfo: z.string().optional(),
-  roomTypes: z.array(RoomType).optional(),
-  lastUpdated: z.coerce.date().optional(),
-})
-
-export const Rent = z.object({
-  rentId: z.string().optional(),
-  leaseId: z.string().optional(),
-  currentRent: z.number(),
-  vat: z.number(),
-  additionalChargeDescription: z.string().optional(),
-  additionalChargeAmount: z.number().optional(),
-  rentStartDate: z.coerce.date().optional(),
-  rentEndDate: z.coerce.date().optional(),
-})
-
-export const RentInfo = z.object({
-  currentRent: Rent,
-  futureRents: z.array(Rent).optional(),
-})
-
-export const WaitingList = z.object({
-  queueTime: z.coerce.date(),
-  queuePoints: z.number(),
-  type: z.number(),
-})
-
-export const BaseContact = z.object({
-  contactCode: z.string(),
-  contactKey: z.string(),
-  leaseIds: z.array(z.string()).optional(),
-  firstName: z.string(),
-  lastName: z.string(),
-  fullName: z.string(),
-  nationalRegistrationNumber: z.string(),
-  birthDate: z.coerce.date(),
-  address: Address.optional(),
-  phoneNumbers: z.array(PhoneNumber).optional(),
-  emailAddress: z.string().optional(),
-  isTenant: z.boolean(),
-  parkingSpaceWaitingList: WaitingList.optional(),
-  specialAttention: z.boolean().optional(),
-})
-
-type Contact = z.infer<typeof BaseContact> & {
-  leases?: Lease[]
-}
-
-export const ContactSchema = BaseContact.extend({
-  leases: z.lazy(() => z.array(LeaseSchema)).optional(),
-})
-
-export const BaseLease = z.object({
+export const Lease = z.object({
   leaseId: z.string(),
   leaseNumber: z.string(),
   leaseStartDate: z.coerce.date(),
   leaseEndDate: z.coerce.date().optional(),
-  status: LeaseStatus,
+  status: z.enum(['Current', 'Upcoming', 'AboutToEnd', 'Ended']),
   tenantContactIds: z.array(z.string()).optional(),
   rentalPropertyId: z.string(),
-  rentalProperty: RentalProperty.optional(),
+  rentalProperty: z
+    .object({
+      rentalPropertyId: z.string(),
+      apartmentNumber: z.number(),
+      size: z.number(),
+      type: z.string(),
+      address: z
+        .object({
+          street: z.string(),
+          number: z.string(),
+          postalCode: z.string(),
+          city: z.string(),
+        })
+        .optional(),
+      rentalPropertyType: z.string(),
+      additionsIncludedInRent: z.string(),
+      otherInfo: z.string().optional(),
+      roomTypes: z
+        .array(
+          z.object({
+            roomTypeId: z.string(),
+            name: z.string(),
+          })
+        )
+        .optional(),
+      lastUpdated: z.coerce.date().optional(),
+    })
+    .optional(),
   type: z.string(),
-  rentInfo: RentInfo.optional(),
-  address: Address.optional(),
+  rentInfo: z
+    .object({
+      currentRent: z.object({
+        rentId: z.string().optional(),
+        leaseId: z.string().optional(),
+        currentRent: z.number(),
+        vat: z.number(),
+        additionalChargeDescription: z.string().optional(),
+        additionalChargeAmount: z.number().optional(),
+        rentStartDate: z.coerce.date().optional(),
+        rentEndDate: z.coerce.date().optional(),
+      }),
+    })
+    .optional(),
+  address: z
+    .object({
+      street: z.string(),
+      number: z.string(),
+      postalCode: z.string(),
+      city: z.string(),
+    })
+    .optional(),
   noticeGivenBy: z.string().optional(),
   noticeDate: z.coerce.date().optional(),
   noticeTimeTenant: z.string().optional(),
@@ -166,13 +76,51 @@ export const BaseLease = z.object({
   contractDate: z.coerce.date().optional(),
   lastDebitDate: z.coerce.date().optional(),
   approvalDate: z.coerce.date().optional(),
-  residentialArea: ResidentialArea.optional(),
-})
-
-type Lease = z.infer<typeof BaseLease> & {
-  tenants?: Contact[]
-}
-
-export const LeaseSchema: z.ZodType<Lease> = BaseLease.extend({
-  tenants: z.lazy(() => ContactSchema.array()).optional(),
+  residentialArea: z
+    .object({
+      code: z.string(),
+      caption: z.string(),
+    })
+    .optional(),
+  tenants: z
+    .array(
+      z.object({
+        contactCode: z.string(),
+        contactKey: z.string(),
+        leaseIds: z.array(z.string()).optional(),
+        firstName: z.string(),
+        lastName: z.string(),
+        fullName: z.string(),
+        nationalRegistrationNumber: z.string(),
+        birthDate: z.coerce.date(),
+        address: z
+          .object({
+            street: z.string(),
+            number: z.string(),
+            postalCode: z.string(),
+            city: z.string(),
+          })
+          .optional(),
+        phoneNumbers: z
+          .array(
+            z.object({
+              phoneNumber: z.string(),
+              type: z.string(),
+              isMainNumber: z.boolean(),
+            })
+          )
+          .optional(),
+        emailAddress: z.string().optional(),
+        isTenant: z.boolean(),
+        parkingSpaceWaitingList: z
+          .object({
+            queueTime: z.coerce.date(),
+            queuePoints: z.number(),
+            type: z.number(),
+          })
+          .optional(),
+        specialAttention: z.boolean().optional(),
+      })
+    )
+    .optional(),
 })

--- a/src/services/lease-service/schemas/lease.ts
+++ b/src/services/lease-service/schemas/lease.ts
@@ -126,7 +126,7 @@ export const Lease = z.object({
     .optional(),
 })
 
-export const GetLeaseForPropertyIdQueryParams = z.object({
+export const GetLeasesByRentalPropertyIdQueryParams = z.object({
   includeUpcomingLeases: z
     .enum(['true', 'false'])
     .optional()

--- a/src/services/lease-service/schemas/lease.ts
+++ b/src/services/lease-service/schemas/lease.ts
@@ -1,0 +1,178 @@
+import { z } from 'zod'
+
+export const LeaseStatus = z.enum([
+  'Current',
+  'Upcoming',
+  'AboutToEnd',
+  'Ended',
+])
+
+export const PhoneNumber = z.object({
+  phoneNumber: z.string(),
+  type: z.string(),
+  isMainNumber: z.boolean(),
+})
+
+export const Address = z.object({
+  street: z.string(),
+  number: z.string(),
+  postalCode: z.string(),
+  city: z.string(),
+})
+
+export const ResidentialArea = z.object({
+  code: z.string(),
+  caption: z.string(),
+})
+
+export const MaterialOption = z.object({
+  materialOptionId: z.string(),
+  caption: z.string(),
+  shortDescription: z.string().optional(),
+  description: z.string().optional(),
+  coverImage: z.string().optional(),
+  images: z.array(z.string()).optional(),
+  roomTypeName: z.string().optional(),
+  materialOptionGroupName: z.string().optional(),
+})
+
+type MaterialOption = z.infer<typeof MaterialOption>
+
+const BaseMaterialOptionGroup = z.object({
+  materialOptionGroupId: z.string(),
+  roomTypeId: z.string(),
+  roomTypeName: z.string().optional(),
+  name: z.string().optional(),
+  actionName: z.string().optional(),
+  type: z.string(),
+})
+
+export type MaterialOptionGroup = z.infer<typeof BaseMaterialOptionGroup> & {
+  materialOptions?: MaterialOption[]
+  materialChoices?: MaterialChoice[]
+}
+
+export const MaterialOptionGroupSchema: z.ZodType<MaterialOptionGroup> =
+  BaseMaterialOptionGroup.extend({
+    materialOptions: z.array(MaterialOption).optional(),
+    materialChoices: z.lazy(() => z.array(MaterialChoiceSchema).optional()),
+  })
+
+const BaseMaterialChoice = z.object({
+  materialChoiceId: z.string(),
+  materialOptionId: z.string(),
+  materialOptionGroupId: z.string(),
+  apartmentId: z.string(),
+  roomTypeId: z.string(),
+  materialOption: MaterialOption.optional(),
+  roomType: z.lazy(() => RoomType).optional(),
+  status: z.string(),
+  dateOfSubmission: z.coerce.date().optional(),
+  dateOfCancellation: z.coerce.date().optional(),
+})
+
+type MaterialChoice = z.infer<typeof BaseMaterialChoice> & {
+  materialOptionGroup?: MaterialOptionGroup
+}
+
+export const MaterialChoiceSchema: z.ZodType<MaterialChoice> =
+  BaseMaterialChoice.extend({
+    materialOptionGroup: MaterialOptionGroupSchema.optional(),
+  })
+
+export const RoomType = z.object({
+  roomTypeId: z.string(),
+  name: z.string(),
+  materialOptionGroups: z.array(MaterialOptionGroupSchema).optional(),
+})
+
+export const RentalProperty = z.object({
+  rentalPropertyId: z.string(),
+  apartmentNumber: z.number(),
+  size: z.number(),
+  type: z.string(),
+  address: Address.optional(),
+  rentalPropertyType: z.string(),
+  additionsIncludedInRent: z.string(),
+  otherInfo: z.string().optional(),
+  roomTypes: z.array(RoomType).optional(),
+  lastUpdated: z.coerce.date().optional(),
+})
+
+export const Rent = z.object({
+  rentId: z.string().optional(),
+  leaseId: z.string().optional(),
+  currentRent: z.number(),
+  vat: z.number(),
+  additionalChargeDescription: z.string().optional(),
+  additionalChargeAmount: z.number().optional(),
+  rentStartDate: z.coerce.date().optional(),
+  rentEndDate: z.coerce.date().optional(),
+})
+
+export const RentInfo = z.object({
+  currentRent: Rent,
+  futureRents: z.array(Rent).optional(),
+})
+
+export const WaitingList = z.object({
+  queueTime: z.coerce.date(),
+  queuePoints: z.number(),
+  type: z.number(),
+})
+
+export const BaseContact = z.object({
+  contactCode: z.string(),
+  contactKey: z.string(),
+  leaseIds: z.array(z.string()).optional(),
+  firstName: z.string(),
+  lastName: z.string(),
+  fullName: z.string(),
+  nationalRegistrationNumber: z.string(),
+  birthDate: z.coerce.date(),
+  address: Address.optional(),
+  phoneNumbers: z.array(PhoneNumber).optional(),
+  emailAddress: z.string().optional(),
+  isTenant: z.boolean(),
+  parkingSpaceWaitingList: WaitingList.optional(),
+  specialAttention: z.boolean().optional(),
+})
+
+type Contact = z.infer<typeof BaseContact> & {
+  leases?: Lease[]
+}
+
+export const ContactSchema = BaseContact.extend({
+  leases: z.lazy(() => z.array(LeaseSchema)).optional(),
+})
+
+export const BaseLease = z.object({
+  leaseId: z.string(),
+  leaseNumber: z.string(),
+  leaseStartDate: z.coerce.date(),
+  leaseEndDate: z.coerce.date().optional(),
+  status: LeaseStatus,
+  tenantContactIds: z.array(z.string()).optional(),
+  rentalPropertyId: z.string(),
+  rentalProperty: RentalProperty.optional(),
+  type: z.string(),
+  rentInfo: RentInfo.optional(),
+  address: Address.optional(),
+  noticeGivenBy: z.string().optional(),
+  noticeDate: z.coerce.date().optional(),
+  noticeTimeTenant: z.string().optional(),
+  preferredMoveOutDate: z.coerce.date().optional(),
+  terminationDate: z.coerce.date().optional(),
+  contractDate: z.coerce.date().optional(),
+  lastDebitDate: z.coerce.date().optional(),
+  approvalDate: z.coerce.date().optional(),
+  residentialArea: ResidentialArea.optional(),
+})
+
+type Lease = z.infer<typeof BaseLease> & {
+  tenants?: Contact[]
+}
+
+export const LeaseSchema: z.ZodType<Lease> = BaseLease.extend({
+  tenants: z.lazy(() => ContactSchema.array()).optional(),
+})

--- a/src/services/lease-service/schemas/lease.ts
+++ b/src/services/lease-service/schemas/lease.ts
@@ -127,9 +127,18 @@ export const Lease = z.object({
 })
 
 export const GetLeaseForPropertyIdQueryParams = z.object({
-  includeUpcomingLeases: z.coerce.boolean().optional().default(false),
-  includeTerminatedLeases: z.coerce.boolean().optional().default(false),
-  includeContacts: z.coerce.boolean().optional().default(false),
+  includeUpcomingLeases: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform((value) => value === 'true'),
+  includeTerminatedLeases: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform((value) => value === 'true'),
+  includeContacts: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform((value) => value === 'true'),
 })
 
 export function mapLease(lease: OnecoreTypesLease): z.infer<typeof Lease> {

--- a/src/services/lease-service/schemas/lease.ts
+++ b/src/services/lease-service/schemas/lease.ts
@@ -1,3 +1,4 @@
+import { Lease as OnecoreTypesLease } from 'onecore-types'
 import { z } from 'zod'
 
 /**
@@ -130,3 +131,36 @@ export const GetLeaseForPropertyIdQueryParams = z.object({
   includeTerminatedLeases: z.coerce.boolean().optional().default(false),
   includeContacts: z.coerce.boolean().optional().default(false),
 })
+
+export function mapLease(lease: OnecoreTypesLease): z.infer<typeof Lease> {
+  return {
+    leaseId: lease.leaseId,
+    leaseNumber: lease.leaseNumber,
+    leaseStartDate: lease.leaseStartDate,
+    leaseEndDate: lease.leaseEndDate,
+    status:
+      lease.status === 0
+        ? 'Current'
+        : lease.status === 1
+          ? 'Upcoming'
+          : lease.status === 2
+            ? 'AboutToEnd'
+            : 'Ended',
+    tenantContactIds: lease.tenantContactIds,
+    rentalPropertyId: lease.rentalPropertyId,
+    rentalProperty: lease.rentalProperty,
+    type: lease.type,
+    rentInfo: lease.rentInfo,
+    address: lease.address,
+    noticeGivenBy: lease.noticeGivenBy,
+    noticeDate: lease.noticeDate,
+    noticeTimeTenant: lease.noticeTimeTenant,
+    preferredMoveOutDate: lease.preferredMoveOutDate,
+    terminationDate: lease.terminationDate,
+    contractDate: lease.contractDate,
+    lastDebitDate: lease.lastDebitDate,
+    approvalDate: lease.approvalDate,
+    residentialArea: lease.residentialArea,
+    tenants: lease.tenants,
+  }
+}

--- a/src/services/lease-service/schemas/lease.ts
+++ b/src/services/lease-service/schemas/lease.ts
@@ -124,3 +124,9 @@ export const Lease = z.object({
     )
     .optional(),
 })
+
+export const GetLeaseForPropertyIdQueryParams = z.object({
+  includeUpcomingLeases: z.coerce.boolean().optional().default(false),
+  includeTerminatedLeases: z.coerce.boolean().optional().default(false),
+  includeContacts: z.coerce.boolean().optional().default(false),
+})

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -19,6 +19,7 @@ import * as replyToOffer from '../../../processes/parkingspaces/internal/reply-t
 import * as factory from '../../../../test/factories'
 import { ProcessStatus } from '../../../common/types'
 import { schemas } from '../schemas'
+import { Lease as LeaseSchema } from '../schemas/lease'
 
 const app = new Koa()
 const router = new KoaRouter()
@@ -46,6 +47,54 @@ describe('lease-service', () => {
     zip: '72266',
     city: 'Västerås',
   }
+
+  describe('GET /leases/for/propertyId/:propertyId', () => {
+    it('responds with 400 for invalid query parameters', async () => {
+      const res = await request(app.callback()).get(
+        '/leases/for/propertyId/123?includeUpcomingLeases=invalid'
+      )
+
+      expect(res.status).toBe(400)
+      expect(res.body).toMatchObject({
+        reason: 'Invalid query parameters',
+        error: expect.any(Object),
+      })
+    })
+
+    it('responds with 500 if adapter fails', async () => {
+      jest
+        .spyOn(tenantLeaseAdapter, 'getLeasesForPropertyId')
+        .mockRejectedValue(new Error('Adapter error'))
+
+      const res = await request(app.callback()).get(
+        '/leases/for/propertyId/123'
+      )
+
+      expect(res.status).toBe(500)
+    })
+
+    it('responds with a list of leases for valid query parameters', async () => {
+      const getLeasesForPropertyIdSpy = jest
+        .spyOn(tenantLeaseAdapter, 'getLeasesForPropertyId')
+        .mockResolvedValue(factory.lease.buildList(1))
+
+      const res = await request(app.callback()).get(
+        '/leases/for/propertyId/123?includeUpcomingLeases=true&includeTerminatedLeases=false&includeContacts=true'
+      )
+
+      expect(res.status).toBe(200)
+      expect(getLeasesForPropertyIdSpy).toHaveBeenCalledWith(
+        '123',
+        expect.objectContaining({
+          includeUpcomingLeases: true,
+          includeTerminatedLeases: false,
+          includeContacts: true,
+        })
+      )
+
+      expect(() => LeaseSchema.array().parse(res.body.content)).not.toThrow()
+    })
+  })
 
   describe('GET /leases/for/:pnr', () => {
     it('responds with a list of leases', async () => {

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -48,10 +48,10 @@ describe('lease-service', () => {
     city: 'Västerås',
   }
 
-  describe('GET /leases/for/propertyId/:propertyId', () => {
+  describe('GET /leases/by-rental-property-id/:rentalPropertyId', () => {
     it('responds with 400 for invalid query parameters', async () => {
       const res = await request(app.callback()).get(
-        '/leases/for/propertyId/123?includeUpcomingLeases=invalid'
+        '/leases/by-rental-property-id/123?includeUpcomingLeases=invalid'
       )
 
       expect(res.status).toBe(400)
@@ -67,7 +67,7 @@ describe('lease-service', () => {
         .mockRejectedValue(new Error('Adapter error'))
 
       const res = await request(app.callback()).get(
-        '/leases/for/propertyId/123'
+        '/leases/by-rental-property-id/123'
       )
 
       expect(res.status).toBe(500)
@@ -79,7 +79,7 @@ describe('lease-service', () => {
         .mockResolvedValue(factory.lease.buildList(1))
 
       const res = await request(app.callback()).get(
-        '/leases/for/propertyId/123?includeUpcomingLeases=true&includeTerminatedLeases=false&includeContacts=true'
+        '/leases/by-rental-property-id/123?includeUpcomingLeases=true&includeTerminatedLeases=false&includeContacts=true'
       )
 
       expect(res.status).toBe(200)


### PR DESCRIPTION
This PR adds an endpoint to fetch leases by property id from leasing.
Adapter function already existed, so I just added the endpoint.

**Note**
In order to add swagger docs for this endpoint to consume from property-tree (and possibly others in the future) I added a Lease zod schema.

This endeavor brought to my attention what I believe are problems with the Lease type from onecore-types. It has circular dependencies which I don't think makes sense. Lease.tenants is a list of Contact, which in turn has a list of Lease on them. 

So the schema I made skips the recursive properties on lease.

