### PR TITLE
MIM-530: add residence status

### DIFF
--- a/src/services/property-base-service/calculate-residence-status.ts
+++ b/src/services/property-base-service/calculate-residence-status.ts
@@ -1,0 +1,24 @@
+import { Lease, LeaseStatus } from 'onecore-types'
+import { z } from 'zod'
+
+import * as schemas from './schemas'
+
+type ResidenceStatus = NonNullable<
+  z.infer<typeof schemas.ResidenceDetailsSchema>['status']
+>
+
+export function calculateResidenceStatus(leases: Lease[]): ResidenceStatus {
+  const leased = leases.some((lease) =>
+    [
+      LeaseStatus.Current,
+      LeaseStatus.Upcoming,
+      LeaseStatus.AboutToEnd,
+    ].includes(lease.status)
+  )
+
+  if (leased) {
+    return 'LEASED'
+  }
+
+  return 'VACANT'
+}

--- a/src/services/property-base-service/schemas.ts
+++ b/src/services/property-base-service/schemas.ts
@@ -111,6 +111,7 @@ export const ResidenceDetailsSchema = z.object({
   id: z.string(),
   code: z.string(),
   name: z.string().nullable(),
+  status: z.enum(['VACANT', 'LEASED']).nullable(),
   location: z.string().nullable(),
   accessibility: z.object({
     wheelchairAccessible: z.boolean(),

--- a/src/services/property-base-service/tests/calculate-residence-status.test.ts
+++ b/src/services/property-base-service/tests/calculate-residence-status.test.ts
@@ -1,0 +1,18 @@
+import { LeaseStatus } from 'onecore-types'
+
+import { calculateResidenceStatus } from '../calculate-residence-status'
+import * as factory from '../../../../test/factories'
+
+describe(calculateResidenceStatus, () => {
+  it('returns "LEASED" when lease status is "Current"', () => {
+    const leases = [factory.lease.build({ status: LeaseStatus.Current })]
+    const status = calculateResidenceStatus(leases)
+    expect(status).toBe('LEASED')
+  })
+
+  it('returns "VACANT" when lease status is "Terminated"', () => {
+    const leases = [factory.lease.build({ status: LeaseStatus.Ended })]
+    const status = calculateResidenceStatus(leases)
+    expect(status).toBe('VACANT')
+  })
+})

--- a/src/services/property-base-service/tests/calculate-residence-status.test.ts
+++ b/src/services/property-base-service/tests/calculate-residence-status.test.ts
@@ -24,7 +24,7 @@ describe(calculateResidenceStatus, () => {
     ).toBe('LEASED')
   })
 
-  it('returns "VACANT" when lease status is "Terminated"', () => {
+  it('returns "VACANT" when lease status is "Ended"', () => {
     const leases = [factory.lease.build({ status: LeaseStatus.Ended })]
     const status = calculateResidenceStatus(leases)
     expect(status).toBe('VACANT')

--- a/src/services/property-base-service/tests/calculate-residence-status.test.ts
+++ b/src/services/property-base-service/tests/calculate-residence-status.test.ts
@@ -4,10 +4,24 @@ import { calculateResidenceStatus } from '../calculate-residence-status'
 import * as factory from '../../../../test/factories'
 
 describe(calculateResidenceStatus, () => {
-  it('returns "LEASED" when lease status is "Current"', () => {
-    const leases = [factory.lease.build({ status: LeaseStatus.Current })]
-    const status = calculateResidenceStatus(leases)
-    expect(status).toBe('LEASED')
+  it('returns "LEASED" when lease status is "Current", "Upcoming" or "AboutToEnd"', () => {
+    expect(
+      calculateResidenceStatus([
+        factory.lease.build({ status: LeaseStatus.Current }),
+      ])
+    ).toBe('LEASED')
+
+    expect(
+      calculateResidenceStatus([
+        factory.lease.build({ status: LeaseStatus.Upcoming }),
+      ])
+    ).toBe('LEASED')
+
+    expect(
+      calculateResidenceStatus([
+        factory.lease.build({ status: LeaseStatus.AboutToEnd }),
+      ])
+    ).toBe('LEASED')
   })
 
   it('returns "VACANT" when lease status is "Terminated"', () => {


### PR DESCRIPTION
- Add status enum to residence schema VACANT | LEASED
- If rental id is available when fetching residence, also fetch leases from leasing and calculate status from lease statuses
