### PR TITLE
ExpiresAt Missing In Action

### DIFF
--- a/src/services/lease-service/helpers/application-profile.ts
+++ b/src/services/lease-service/helpers/application-profile.ts
@@ -22,7 +22,6 @@ export function makeAdminApplicationProfileRequestParams(
       expiresAt: null,
       housingReference: {
         ...body.housingReference,
-        expiresAt: null,
         reviewedAt:
           body.housingReference.reviewStatus === 'PENDING' ? null : now,
       },

--- a/src/services/lease-service/helpers/application-profile.ts
+++ b/src/services/lease-service/helpers/application-profile.ts
@@ -22,6 +22,7 @@ export function makeAdminApplicationProfileRequestParams(
       expiresAt: null,
       housingReference: {
         ...body.housingReference,
+        expiresAt: null,
         reviewedAt:
           body.housingReference.reviewStatus === 'PENDING' ? null : now,
       },
@@ -58,7 +59,10 @@ export function makeAdminApplicationProfileRequestParams(
       expiresAt: existingProfile.expiresAt,
       housingReference: {
         ...body.housingReference,
-        expiresAt,
+        expiresAt:
+          body.housingReference.reviewStatus === 'REJECTED'
+            ? body.housingReference.expiresAt
+            : expiresAt,
         reviewedAt: now,
       },
     }
@@ -89,7 +93,9 @@ function getDiffType(
 
   const reviewed =
     incomingHousingReference.reviewStatus !==
-    existingHousingReference.reviewStatus
+      existingHousingReference.reviewStatus ||
+    (incomingHousingReference.reviewStatus == 'REJECTED' &&
+      incomingHousingReference.expiresAt !== existingHousingReference.expiresAt)
 
   const profileUpdate =
     JSON.stringify(incomingProfile) !== JSON.stringify(existingProfile)

--- a/src/services/lease-service/schemas/admin/application-profile/index.ts
+++ b/src/services/lease-service/schemas/admin/application-profile/index.ts
@@ -17,6 +17,7 @@ export const UpdateApplicationProfileRequestParams =
           comment: true,
           reviewedBy: true,
           reasonRejected: true,
+          expiresAt: true,
         }
       ),
   })

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -717,6 +717,7 @@ describe('lease-service', () => {
         housingReference: {
           ...existingProfile.housingReference,
           reviewStatus: 'REJECTED',
+          expiresAt: new Date('2022-01-01'),
         },
       })
 


### PR DESCRIPTION
Core shouldn't set housingReference.ExpiresAt to null. ExpiresAt will be handled in Leasing