### PR TITLE
Fix: Swagger Reference Error for Rental Object fix

### DIFF
--- a/src/services/property-management-service/index.ts
+++ b/src/services/property-management-service/index.ts
@@ -674,7 +674,7 @@ export const routes = (router: KoaRouter) => {
    *                 content:
    *                   type: array
    *                   items:
-   *                     type: object
+   *                     type: $ref: '#/components/schemas/RentalObject'
    *       '500':
    *         description: Internal server error. Failed to fetch rental object.
    *         content:
@@ -685,6 +685,11 @@ export const routes = (router: KoaRouter) => {
    *                 error:
    *                   type: string
    *                   description: The error message.
+   * components:
+   *   schemas:
+   *     RentalObject:
+   *       type: object
+   *       description: Represents a rental object.
    */
   router.get('(.*)/rental-object/by-code/:rentalObjectCode', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)


### PR DESCRIPTION
Component Schema was missing for RentalObject. That did run and build nicely for core but didn't work out for property-tree In the future a zod-schema would be required to actually consume this endpoint in property-tree but this addition will make it run without ts-errors