### PR TITLE
⚠️ fix: housing type nullable

### DIFF
--- a/src/services/lease-service/helpers/application-profile.ts
+++ b/src/services/lease-service/helpers/application-profile.ts
@@ -29,7 +29,7 @@ export function makeAdminApplicationProfileRequestParams(
       lastUpdatedAt: null,
       expiresAt: null,
       housingReference: {
-        reviewStatus: 'PENDING',
+        reviewStatus: incoming.housingReference.reviewStatus,
         phone: incoming.housingReference.phone,
         email: incoming.housingReference.email,
         comment: incoming.housingReference.comment,

--- a/src/services/lease-service/helpers/application-profile.ts
+++ b/src/services/lease-service/helpers/application-profile.ts
@@ -129,16 +129,13 @@ export function makeAdminApplicationProfileRequestParams(
   }
 }
 
-const ComparableProfileSchema = z.object({
-  numAdults: z.number(),
-  numChildren: z.number(),
-  housingTypeDescription: z.string().nullable(),
-  landlord: z.string().nullable(),
-  housingType: z.nullable(
-    schemas.admin.applicationProfile.UpdateApplicationProfileRequestParams.shape
-      .housingType
-  ),
-})
+type ComparableProfile = {
+  numAdults: number
+  numChildren: number
+  housingType: string | null
+  landlord: string | null
+  housingTypeDescription: string | null
+}
 
 /*
  * This function takes the incoming application profile,
@@ -147,7 +144,7 @@ const ComparableProfileSchema = z.object({
  * 1. Check wether housing reference was reviewed.
  * 2. Check wether any profile fields were updated.
  *    The existing application profile can have a null housingType
- *    and the incoming _can not_. So I used an intermediary schema (ComparableProfileSchema) to parse
+ *    and the incoming _can not_. So I used an intermediary type (ComparableProfile) to map
  *    them both into 'comparable' objects, i.e objects with identical fields.
  */
 function getDiffType(
@@ -157,8 +154,21 @@ function getDiffType(
   const incomingHousingReference = incoming.housingReference
   const existingHousingReference = existing.housingReference
 
-  const incomingProfile = ComparableProfileSchema.parse(incoming)
-  const existingProfile = ComparableProfileSchema.parse(existing)
+  const incomingProfile: ComparableProfile = {
+    housingType: incoming.housingType,
+    housingTypeDescription: incoming.housingTypeDescription,
+    landlord: incoming.landlord,
+    numAdults: incoming.numAdults,
+    numChildren: incoming.numChildren,
+  }
+
+  const existingProfile: ComparableProfile = {
+    housingType: existing.housingType,
+    housingTypeDescription: existing.housingTypeDescription,
+    landlord: existing.landlord,
+    numAdults: existing.numAdults,
+    numChildren: existing.numChildren,
+  }
 
   const reviewed =
     incomingHousingReference.reviewStatus !==

--- a/src/services/lease-service/helpers/application-profile.ts
+++ b/src/services/lease-service/helpers/application-profile.ts
@@ -9,8 +9,8 @@ type UpdateAdminApplicationProfileRequestParams = z.infer<
 >
 
 /**
- * This function returns different update payloads
- * based on conditions.
+ * This function takes the incoming update payload and the optional existing profile
+ * and returns a new update payload based on conditions.
  */
 export function makeAdminApplicationProfileRequestParams(
   incoming: UpdateAdminApplicationProfileRequestParams,
@@ -142,13 +142,13 @@ const ComparableProfileSchema = z.object({
 
 /*
  * This function takes the incoming application profile,
- * the existing application profile and compares them.
+ * the existing application profile, compares them and returns what changed.
  *
- * 1. Check wether profile was reviewed.
- * 2. Check if any profile fields were updated.
+ * 1. Check wether housing reference was reviewed.
+ * 2. Check wether any profile fields were updated.
  *    The existing application profile can have a null housingType
  *    and the incoming _can not_. So I used an intermediary schema (ComparableProfileSchema) to parse
- *    them both into comparable objects.
+ *    them both into 'comparable' objects, i.e objects with identical fields.
  */
 function getDiffType(
   incoming: UpdateAdminApplicationProfileRequestParams,

--- a/src/services/lease-service/helpers/application-profile.ts
+++ b/src/services/lease-service/helpers/application-profile.ts
@@ -80,16 +80,26 @@ export function makeAdminApplicationProfileRequestParams(
   }
 }
 
+const ComparableProfileSchema = z.object({
+  numAdults: z.number(),
+  numChildren: z.number(),
+  housingTypeDescription: z.string().nullable(),
+  landlord: z.string().nullable(),
+  housingType: z.nullable(
+    schemas.admin.applicationProfile.UpdateApplicationProfileRequestParams.shape
+      .housingType
+  ),
+})
+
 function getDiffType(
-  params: UpdateAdminApplicationProfileRequestParams,
+  incoming: UpdateAdminApplicationProfileRequestParams,
   existing: leasingAdapter.GetApplicationProfileResponseData
 ): 'profile' | 'review' | 'both' | 'neither' {
-  const { housingReference: incomingHousingReference, ...incomingProfile } =
-    params
-  const { housingReference: existingHousingReference, ...existingProfile } =
-    schemas.admin.applicationProfile.UpdateApplicationProfileRequestParams.parse(
-      existing
-    )
+  const incomingHousingReference = incoming.housingReference
+  const existingHousingReference = existing.housingReference
+
+  const incomingProfile = ComparableProfileSchema.parse(incoming)
+  const existingProfile = ComparableProfileSchema.parse(existing)
 
   const reviewed =
     incomingHousingReference.reviewStatus !==

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -764,6 +764,65 @@ describe('lease-service', () => {
         existingProfile.housingReference.expiresAt?.getTime() as number
       )
     })
+
+    it('allows update with null housingType on existing profile', async () => {
+      const existingProfile = factory.applicationProfile.build({
+        housingType: null,
+        numAdults: 2,
+        lastUpdatedAt: new Date('2021-01-01'),
+        expiresAt: new Date('2021-01-01'),
+        housingReference: {
+          reviewedAt: new Date('2021-01-01'),
+          expiresAt: new Date('2021-01-01'),
+          reviewStatus: 'PENDING',
+        },
+      })
+
+      const updatedProfile = factory.applicationProfile.build({
+        ...existingProfile,
+        housingType: 'RENTAL',
+        housingReference: {
+          ...existingProfile.housingReference,
+          reviewStatus: 'REJECTED',
+          expiresAt: new Date('2022-01-01'),
+        },
+      })
+
+      jest
+        .spyOn(tenantLeaseAdapter, 'getApplicationProfileByContactCode')
+        .mockResolvedValueOnce({
+          ok: true,
+          data: existingProfile,
+        })
+
+      const adapterSpy = jest
+        .spyOn(
+          tenantLeaseAdapter,
+          'createOrUpdateApplicationProfileByContactCode'
+        )
+        .mockResolvedValueOnce({
+          ok: true,
+          data: factory.applicationProfile.build(),
+        })
+
+      const res = await request(app.callback())
+        .post(
+          `/contacts/${existingProfile.contactCode}/application-profile/admin`
+        )
+        .send(updatedProfile)
+
+      expect(res.status).toBe(200)
+      expect(() =>
+        schemas.admin.applicationProfile.UpdateApplicationProfileResponseData.parse(
+          res.body.content
+        )
+      ).not.toThrow()
+
+      expect(adapterSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ housingType: updatedProfile.housingType })
+      )
+    })
   })
 
   describe('POST /contacts/:contactCode/application-profile/client', () => {


### PR DESCRIPTION
# ⚠️ **Do not merge before understanding the description below**

**This PR contains a fix for a bug reported yesterday 2025-07-01**

_Context:_
One user couldn't save their application profile on mimer.nu when prompted before making a note of interest on an apartment. I believe the issue is they have some obscure combo of old phone(!) and browser, making the select input boxes not rendering under the text 
> Du har tidigare angett att ni är en (1) person i hushållet. Stämmer det för din ansökan

...resulting in the form not submitting because of this value missing.

The user calls CS and asks for help updating their profile. CS visits medarbetarportalen, searches the user and tries to update their profile. **This is where the error adressed in this PR occurs.**
Problem is that during onecore-core internal logic that compares the optionally existing profile and the incoming update parameters, we parse the existing profile with a schema that expects `profile.housingType` to be _not null_. 

If the user has never successfully updated their own information (like in this case), `profile.housingType` _is in fact null_. This results in a zod parsing exception, giving response 500 back to internal portal.

**Solution**
In the helper function we use to construct update payloads based on incoming profile and existing profile, allow null `profile.housingType` when comparing existing and incoming profile.

I also added some comments to existing fuctions and refactored/renamed stuff a bit in an attempt to clarify intent.
PR is probably easier to understand if read commit by commit.

The branch that this PR is based on, `fix/housing-type` is based on the release commit [1.0.230](494f60166d956340cb072a60ba8bdb54a5982c76). I _think_ I've done that correctly to prepare the branch as a hotfix release so it's based on the latest prod release, not incorporating any other changes to `main` since then.

We decided to wait with releasing this mainly because:
- At the time of writing, we (us that are currently working) are not super comfortable with release/hotfix/release/rollback procedure.
- We think it's an rather unusual scenario that likely will not cause a lot of problems until more people are back from vacation and we feel more comfortable releasing this.

